### PR TITLE
Revise implementation contract into a concrete v1 specification

### DIFF
--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -32,43 +32,55 @@ point*: pre-triage, triage, or post-triage (§10).
   into two isolated cached virtualenvs (`uv pip` when on `PATH`, stdlib `venv` + `pip`
   fallback). Escape hatch: `--old-cmd`/`--new-cmd` point at pre-built executables.
 - Three-step runs: a **fetch** step (network permitted; git clones plus dependency prefetch
-  into a local wheel cache, wheels preferred; no code from the detector refs executes;
-  every fetch is recorded in the run manifest — URLs, resolved SHAs, installed versions),
-  then a **build** step (networking disabled; the detector installs from the local cache,
-  e.g. `--no-index --find-links`, so build-backend hooks run sandboxed; Rust detectors
-  prefetch crates during fetch and build `--offline`), then an **analysis** step
-  (networking disabled, §11). Corpus refs are resolved once per run and then pinned
-  (including latest-on-branch mode); both detector revisions analyze byte-identical
-  checkouts.
+  into a local wheel cache, wheels preferred; detector-ref dependencies are resolved by
+  statically parsing PEP 621 `[project]` metadata — no build backend is invoked, so no code
+  from the detector refs executes; every fetch is recorded in the run manifest — URLs,
+  resolved SHAs, installed versions), then a **build** step (networking disabled per §11;
+  the detector installs from the local cache, e.g. `--no-index --find-links`, so
+  build-backend hooks run sandboxed; Rust detectors prefetch crates during fetch and build
+  `--offline`), then an **analysis** step (networking disabled per §11). Corpus refs are
+  resolved once per run and then pinned (including latest-on-branch mode); both detector
+  revisions analyze byte-identical checkouts.
 - Trust model: detector refs and corpus content are untrusted and execute only with
-  networking disabled and no credentials; third-party dependencies fetched from package
-  indexes are supply-chain-trusted like any development dependency. As in all CI, running a
-  primer on a PR executes that PR's code — the guarantee is isolation, not avoidance.
+  networking disabled (where enforced — §11, §16) and no credentials; third-party
+  dependencies fetched from package indexes are supply-chain-trusted like any development
+  dependency. As in all CI, running a primer on a PR executes that PR's code — the
+  guarantee is isolation, not avoidance.
 - Environment integrity: virtualenv cache entries under the `platformdirs` cache directory
   are keyed by the full fingerprint (repository, resolved SHA, adapter build-recipe hash,
   Python version and ABI, platform tag, installer name and version) and guarded by
   `filelock`; checkout caches are keyed by (repository, SHA). The manifest records the
-  resolved dependency freeze of both environments. A base/head pair is **comparable** iff
-  the non-detector dependency delta is empty; any non-empty delta triggers an automatic
-  paired same-run rebuild, and only a delta that survives same-run paired resolution is
-  ref-attributable (reported as context). Attribution is temporal, never textual:
-  declared-requirement differences between the refs do not excuse a cached pair. The
-  manifest records a `comparable` flag; `--fail-on` gating and `bisect` refuse to act on
+  resolved dependency freeze of both environments. Cached pairs with an empty non-detector
+  dependency delta are used directly; any non-empty delta triggers an automatic paired
+  same-run rebuild. Attribution is temporal, never textual: declared-requirement
+  differences between the refs do not excuse a cached pair, and only a delta that survives
+  same-run paired resolution is ref-attributable. A run whose environments matched exactly
+  from cache or went through paired same-run resolution is **comparable**; a surviving
+  delta is recorded in the manifest and rendered prominently in the report as
+  environment-delta context — a large blast radius from a dependency bump is itself a
+  useful finding. The `comparable` flag is false only for unmanaged escape-hatch runs
+  (`--old-cmd`/`--new-cmd`); `--fail-on` gating and `bisect` refuse to act on
   non-comparable runs. `--fresh` forces same-run rebuilds of both environments.
-- Concurrency: `asyncio` orchestrates per-project subprocesses with a configurable
-  parallelism limit and a per-(project, tool) timeout.
+- Concurrency: `asyncio` orchestrates per-project subprocesses; parallelism is set by
+  `--jobs N` and the default per-(project, tool) timeout by `--timeout S` (§12), with
+  per-(project, tool) `timeout` overrides in the corpus TOML (§5).
 
 ## 4. Supported detectors
 
-- v1 adapters: `vulture` and `skylos` (pure Python, generic source-install path) in
-  Phase 1; `culler` and `mollify` (Rust/maturin builds requiring a declared toolchain) in
-  Phase 2. All four are permissively licensed, uv-installable, and actively developed.
+- v1 adapters: `vulture` and `skylos` (generic source-install path: their own builds are
+  pure Python; compiled dependencies, such as skylos's tree-sitter grammars and libcst,
+  arrive as prefetched wheels) in Phase 1; `culler` and `mollify` (Rust/maturin builds
+  requiring a declared toolchain) in Phase 2. All four are permissively licensed,
+  uv-installable, and actively developed.
 - Adapters implement a typed `Protocol`: raw invocation output → `list[Finding]`, declaring
   capabilities (e.g. has-confidence, output format) and a **build recipe** — build backend
   plus toolchain prerequisites with minimum versions (e.g. Rust and maturin for `culler`
   and `mollify`) — which the runner verifies before building and CI provisions for gated
-  detectors. The interface is not Python-specific (paths plus optional symbol), leaving
-  room for tools such as `knip`.
+  detectors. v1 build recipes require static PEP 621 metadata (§3); dynamic-metadata
+  detectors are unsupported. Adapters ingest only dead-code finding kinds: other report
+  categories (e.g. skylos's security, secrets, and quality findings) are filtered at the
+  adapter. The interface is not Python-specific (paths plus optional symbol), leaving room
+  for tools such as `knip`.
 - Future candidates (non-normative): `pydeadcode`, `dangle`, `deadpy`, `uncalled`, and
   subset-capability tools (ruff, mypy, pyright, CodeQL).
 - Licensing rule: GPL/AGPL detectors (e.g. `deadcode` AGPL-3.0, pylint GPL-2.0) may only
@@ -82,9 +94,12 @@ point*: pre-triage, triage, or post-triage (§10).
 - Per-project fields: `name` (unique key; the same repository may appear under distinct
   names to allow multiple pins), `repo` URL, `license` (SPDX ID), exactly one of `pin`
   (commit SHA) or `branch` (latest-on-branch), and per-tool tables with command/argument
-  overrides, target paths, `expected_clean: bool`, declared `cost` in CPU-seconds
-  (approximate, reference runner; measured actuals are recorded in the report), and
-  include/exclude tool lists.
+  overrides, target paths, `expected_clean: bool`, `timeout` overrides (§3), declared
+  `cost` in CPU-seconds (approximate, reference runner; measured actuals are recorded in
+  the report), and include/exclude tool lists.
+- `expected_clean` semantics: findings or a nonzero tool exit on the base side of an
+  expected-clean (project, tool) pair are reported as **corpus-integrity warnings** (the
+  comparison still runs); `--fail-on corpus-integrity` opts into gating on them.
 - Ad-hoc mode: a single target repository given on the CLI with default settings.
 - Selection: by name (`-k`), `--all`, or `--max-cost SECONDS` (greedy under declared cost
   for the chosen tool).
@@ -99,6 +114,9 @@ point*: pre-triage, triage, or post-triage (§10).
   compares against the declared SPDX ID; mismatches fail the check. Detection is
   advisory-strength (licensee is imperfect) but the check is binding in CI. Implemented with
   `httpx` (the `[license]` extra) and runnable locally via `corpus license-check`.
+- v1 corpus repositories must be GitHub-hosted; `corpus validate` rejects other hosts. The
+  API reports the default-branch license, which can differ from the tree at a pinned SHA;
+  the check remains advisory-strength, with PR review as the backstop.
 
 ## 7. Schemas and finding identity
 
@@ -125,7 +143,9 @@ point*: pre-triage, triage, or post-triage (§10).
   Stages: (1) full-field-equal occurrences are removed by multiset intersection;
   (2) remaining occurrences sharing (identity, start line) are paired in canonical-key
   order as `changed`; (3) remaining occurrences sharing identity are paired across lines
-  in canonical-key order as `changed`; (4) leftovers classify as `new` or `dropped`. After
+  by a deterministic order-preserving alignment (both sides in canonical-key order, gaps
+  allowed) minimizing total start-line distance, ties broken toward earlier lines, as
+  `changed`; (4) leftovers classify as `new` or `dropped`. After
   stage 1, canonical-key ties occur only between fully identical, interchangeable
   occurrences. `changed` carries a `changed_fields ⊆ {line-span, message, confidence}` set
   (confidence only for tools declaring that capability). Every normalized observable field
@@ -145,8 +165,8 @@ point*: pre-triage, triage, or post-triage (§10).
   quoting so downstream LLM consumers structurally see them as data. Sanitization is
   mandatory and not hook-removable.
 - Exit codes: 0 for any successful run regardless of diff size; opt-in
-  `--fail-on {new,dropped,any}` gating; distinct nonzero codes for run failure vs. gate
-  failure.
+  `--fail-on {new,dropped,any,corpus-integrity}` gating; distinct nonzero codes for run
+  failure vs. gate failure.
 
 ## 10. Hook system
 
@@ -182,11 +202,13 @@ point*: pre-triage, triage, or post-triage (§10).
   passes a `shell` keyword. (The bandit S rules alone are insufficient: S603 flags every
   `subprocess` call, safe or not, and no S rule flags `asyncio.create_subprocess_shell`.)
   This guards against accident; in-repo code is trusted (§11 trust boundary).
-- Network isolation: analysis-phase subprocesses run with networking disabled (Linux network
-  namespaces or a container with `--network=none`), enforced on the Linux reference platform
-  and in CI, best-effort elsewhere. The manifest records whether isolation was enforced, and
-  reports flag unenforced runs. This also limits the blast radius of a malicious corpus
-  repository exploiting a detector parser bug.
+- Network isolation: build- and analysis-step subprocesses run with networking disabled
+  (Linux network namespaces or a container with `--network=none`), enforced on the Linux
+  reference platform and in CI, best-effort elsewhere. `--no-index` alone is not isolation
+  — build-backend hooks can open arbitrary sockets; the sandbox is the guarantee. The
+  manifest records whether isolation was enforced, and reports flag unenforced runs. This
+  also limits the blast radius of a malicious corpus repository exploiting a detector
+  parser bug.
 - Corpus code execution: the core (Phases 1–2) never executes corpus code — detectors only
   parse it. Any workflow that executes corpus code (coverage evidence, runner files,
   distillation; Phases 3–4) runs only inside an isolated container: no network, read-only
@@ -202,7 +224,7 @@ printing the package version and `SCHEMA_VERSION`. Commands:
 
 - `run --tool T --repo URL --old REF --new REF [-k SEL | --all | --max-cost S]
   [--max-results N] [--excerpt-lines N] [--output text|json|github] [--fail-on ...]
-  [--fresh] [--old-cmd CMD --new-cmd CMD] [--project URL]`
+  [--jobs N] [--timeout S] [--fresh] [--old-cmd CMD --new-cmd CMD] [--project URL]`
 - `corpus validate` — parse and validate the corpus TOML.
 - `corpus license-check` — §6, locally or in CI.
 - `bisect --report REPORT.json --finding ID [--line N] [--occurrence N] --good REF
@@ -215,7 +237,9 @@ printing the package version and `SCHEMA_VERSION`. Commands:
   class: `new` → first commit where the head occurrence is present; `dropped` → first
   where the base occurrence is absent; `changed` → first where the occurrence deviates
   from its base-side values in any of the finding's `changed_fields`. `--predicate`
-  overrides.
+  overrides. Bisect assumes the predicate is monotonic between `--good` and `--bad`; for
+  oscillating findings (§14 expects these to exist) it reports *a* transition commit, not
+  necessarily the unique cause.
 - `schema export` — regenerate `liveness_primer/schemas/`.
 
 ## 13. Internal corpus
@@ -226,6 +250,10 @@ printing the package version and `SCHEMA_VERSION`. Commands:
   extraction date), and an optional runner link — a repo-relative path to a runner file
   (e.g. `corpus_runners/<name>.py`) that executably demonstrates the evidence in ambiguous
   cases. Runner files execute only under the §11 container-isolation rules.
+- Verdict semantics: `no-coverage` means an expected-meaningful coverage run reported no
+  coverage of the target; `unknown` means coverage has not been run, is not runnable, or
+  structurally cannot produce a meaningful result for that code (e.g. certain runtime
+  decorators).
 - Rule: coverage evidence can only support `live`; absence of coverage yields `no-coverage`,
   never `dead`.
 
@@ -250,7 +278,9 @@ subject to the §11 container-isolation rule.
   against golden files; hooks as pure functions.
 - An AST-walking test enforces the §11 launcher rule: no call anywhere in the package
   passes a `shell` keyword, and no module outside the launcher reaches the raw subprocess
-  APIs (backstopping the `TID251` ban in `ruff.toml`).
+  APIs — including event-loop instance methods (`loop.subprocess_exec`/
+  `loop.subprocess_shell`), which qualified-name banning cannot see (backstopping the
+  `TID251` ban in `ruff.toml`).
 - All repository QA rules in AGENTS.md apply: full branch and line coverage with non-vacuous
   tests, enforced by the existing coverage.py CI gate.
 

--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -31,19 +31,30 @@ point*: pre-triage, triage, or post-triage (§10).
 - The detector is obtained by cloning its repository and installing the base and head refs
   into two isolated cached virtualenvs (`uv pip` when on `PATH`, stdlib `venv` + `pip`
   fallback). Escape hatch: `--old-cmd`/`--new-cmd` point at pre-built executables.
-- Two-phase runs: an **acquisition** phase (git fetches, package installs) in which network
-  access is permitted and every fetch is recorded in the run manifest (URLs, resolved SHAs,
-  installed versions), followed by an **analysis** phase whose subprocesses run with
-  networking disabled (§11). Corpus refs are resolved once per run and then pinned
+- Three-step runs: a **fetch** step (network permitted; git clones plus dependency prefetch
+  into a local wheel cache, wheels preferred; no code from the detector refs executes;
+  every fetch is recorded in the run manifest — URLs, resolved SHAs, installed versions),
+  then a **build** step (networking disabled; the detector installs from the local cache,
+  e.g. `--no-index --find-links`, so build-backend hooks run sandboxed; Rust detectors
+  prefetch crates during fetch and build `--offline`), then an **analysis** step
+  (networking disabled, §11). Corpus refs are resolved once per run and then pinned
   (including latest-on-branch mode); both detector revisions analyze byte-identical
   checkouts.
+- Trust model: detector refs and corpus content are untrusted and execute only with
+  networking disabled and no credentials; third-party dependencies fetched from package
+  indexes are supply-chain-trusted like any development dependency. As in all CI, running a
+  primer on a PR executes that PR's code — the guarantee is isolation, not avoidance.
 - Environment integrity: virtualenv cache entries under the `platformdirs` cache directory
-  are keyed by the full fingerprint (repository, resolved SHA, Python version and ABI,
-  platform tag, installer name and version) and guarded by `filelock`; checkout caches are
-  keyed by (repository, SHA). The manifest records the resolved dependency freeze of both
-  environments, and the report must surface any non-detector dependency delta between the
-  base and head environments as an explicit drift warning. `--fresh` forces same-run
-  rebuilds of both environments.
+  are keyed by the full fingerprint (repository, resolved SHA, adapter build-recipe hash,
+  Python version and ABI, platform tag, installer name and version) and guarded by
+  `filelock`; checkout caches are keyed by (repository, SHA). The manifest records the
+  resolved dependency freeze of both environments. A base/head pair is **comparable** iff
+  the non-detector dependency delta is empty or attributable to declared-requirement
+  differences between the two refs; a non-comparable pair triggers an automatic paired
+  same-run rebuild, after which any remaining delta is ref-attributable by construction and
+  reported as context. The manifest records a `comparable` flag; `--fail-on` gating and
+  `bisect` refuse to act on non-comparable runs. `--fresh` forces same-run rebuilds of both
+  environments.
 - Concurrency: `asyncio` orchestrates per-project subprocesses with a configurable
   parallelism limit and a per-(project, tool) timeout.
 
@@ -107,12 +118,15 @@ point*: pre-triage, triage, or post-triage (§10).
 
 ## 8. Diff engine
 
-- Both revisions see identical files. Matching is exact (identity, line) first, then
-  per-identity multiset reconciliation of the remaining occurrences; results classify as
-  `new`, `dropped`, or `changed`, where `changed` carries a
-  `changed_fields ⊆ {line-span, message, confidence}` set (confidence only for tools
-  declaring that capability). Every normalized observable field participates in the
-  comparison; no identity-stable behavior change may go silently unclassified.
+- Both revisions see identical files. Matching is deterministic and order-independent:
+  (1) full-field-equal occurrences are removed by multiset intersection; (2) remaining
+  occurrences sharing (identity, line) are paired in canonical sort order (message, then
+  confidence) as `changed`; (3) remaining occurrences sharing identity are paired across
+  lines in sorted-line order as `changed`; (4) leftovers classify as `new` or `dropped`.
+  `changed` carries a `changed_fields ⊆ {line-span, message, confidence}` set (confidence
+  only for tools declaring that capability). Every normalized observable field participates
+  in the comparison; no identity-stable behavior change may go silently unclassified, and
+  the canonical ordering makes reports reproducible.
 - Caps on maximum results and excerpt lines are configurable; the report always states
   totals before truncation (new/dropped/changed counts, with confidence changes broken out,
   per project and overall) and notes any truncation. Rendered reports cap message-only
@@ -153,12 +167,17 @@ point*: pre-triage, triage, or post-triage (§10).
 - Injection: defense-in-depth, not *detection* — excerpts are untrusted, sanitization is
   mandatory, and an optional deny-pattern pre-triage hook may veto ingesting an entire
   repository. All best-effort; no component claims to detect prompt injection reliably.
-- Subprocess hygiene: every subprocess launch uses an argv list with `shell=False`; every
-  argv element originates from typed, validated models; per-tool corpus commands are argv
-  lists, never shell strings; corpus content is never interpolated into any command; no
-  `eval`/`exec` of dynamic content anywhere. (ruff `ALL` includes the bandit rules —
-  S602/S604, S102/S307 — and AGENTS.md forbids `noqa`, so the linter mechanically enforces
-  this clause.)
+- Subprocess hygiene: all subprocess launches go through a single audited launcher module
+  that accepts only typed argv lists and exposes no shell parameter; every argv element
+  originates from typed, validated models; per-tool corpus commands are argv lists, never
+  shell strings; corpus content is never interpolated into any command; no `eval`/`exec`
+  of dynamic content anywhere. Enforcement (verified against the pinned ruff): the raw
+  APIs (`subprocess.*`, `os.system`/`os.popen`, `asyncio.create_subprocess_shell`/`_exec`)
+  are banned repo-wide via `TID251` banned-api in `ruff.toml` with a per-file exemption
+  for the launcher, and an AST-walking unit test asserts that no call in the package
+  passes a `shell` keyword. (The bandit S rules alone are insufficient: S603 flags every
+  `subprocess` call, safe or not, and no S rule flags `asyncio.create_subprocess_shell`.)
+  This guards against accident; in-repo code is trusted (§11 trust boundary).
 - Network isolation: analysis-phase subprocesses run with networking disabled (Linux network
   namespaces or a container with `--network=none`), enforced on the Linux reference platform
   and in CI, best-effort elsewhere. The manifest records whether isolation was enforced, and
@@ -174,20 +193,23 @@ point*: pre-triage, triage, or post-triage (§10).
 
 ## 12. CLI surface
 
-`argparse`. Commands:
+`argparse`. Every command accepts `-h`/`--help`; the root parser accepts `--version`,
+printing the package version and `SCHEMA_VERSION`. Commands:
 
 - `run --tool T --repo URL --old REF --new REF [-k SEL | --all | --max-cost S]
   [--max-results N] [--excerpt-lines N] [--output text|json|github] [--fail-on ...]
   [--fresh] [--old-cmd CMD --new-cmd CMD] [--project URL]`
 - `corpus validate` — parse and validate the corpus TOML.
 - `corpus license-check` — §6, locally or in CI.
-- `bisect --report REPORT.json --finding ID [--line N] --good REF --bad REF [--repo URL]
-  [--predicate P]` — binary search over detector commits. The prior report supplies the
-  manifest (detector repository, corpus pins), so every step reproduces the identical
-  checkout; the finding locator resolves the affected project, which is the only project
-  run. The predicate defaults from the finding's diff class in the report (`new` → first
-  commit where present; `dropped` → first where absent; confidence change → first where
-  confidence differs from base) and may be overridden.
+- `bisect --report REPORT.json --finding ID [--line N] [--occurrence N] --good REF
+  --bad REF [--repo URL] [--predicate P]` — binary search over detector commits. The prior
+  report supplies the manifest (detector repository, corpus pins), so every step reproduces
+  the identical checkout; the finding locator resolves to a full base occurrence in the
+  report, and the affected project is the only project run. When several occurrences share
+  (identity, line), `--occurrence` indexes the report's canonical ordering (§8). Default
+  predicate by diff class: `new` → first commit where the occurrence is present; `dropped`
+  → first where absent; `changed` → first where the occurrence deviates from its base
+  value in any of the finding's `changed_fields`. `--predicate` overrides.
 - `schema export` — regenerate `liveness_primer/schemas/`.
 
 ## 13. Internal corpus
@@ -220,6 +242,9 @@ subject to the §11 container-isolation rule.
   synthetic projects with injected characteristics.
 - Adapters are tested against recorded raw-output fixtures; the diff engine and reports
   against golden files; hooks as pure functions.
+- An AST-walking test enforces the §11 launcher rule: no call anywhere in the package
+  passes a `shell` keyword, and no module outside the launcher reaches the raw subprocess
+  APIs (backstopping the `TID251` ban in `ruff.toml`).
 - All repository QA rules in AGENTS.md apply: full branch and line coverage with non-vacuous
   tests, enforced by the existing coverage.py CI gate.
 
@@ -239,10 +264,10 @@ design intentionally blocks it, but it is not gated in CI initially.
 ## 18. Package layout (informative)
 
 `cli.py`, `config.py` (corpus models), `corpus.py` (checkout and pin resolution),
-`envcache.py`, `runner.py`, `tools/` (adapter protocol plus one module per adapter),
-`findings.py`, `diffing.py`, `report/`, `hooks/` (protocols, `TriageSafetyError`, sanitizer,
-subprocess bridge), `schemas/`, `bisect.py`, `testing/` (fake detector, fake project
-factory), `internal_corpus/`.
+`envcache.py`, `runner.py`, `launcher.py` (the audited subprocess launcher, §11), `tools/`
+(adapter protocol plus one module per adapter), `findings.py`, `diffing.py`, `report/`,
+`hooks/` (protocols, `TriageSafetyError`, sanitizer, subprocess bridge), `schemas/`,
+`bisect.py`, `testing/` (fake detector, fake project factory), `internal_corpus/`.
 
 ## 19. Phases and acceptance criteria
 

--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -20,32 +20,44 @@ v1 non-goals:
 
 *Detector*: the dead-code tool under test. *Corpus project*: a repository the detector runs
 against. *Finding*: one normalized detector report item. *Finding identity*: the stable hash
-naming a finding across runs (§7). *Diff class*: `new`, `dropped`, or `confidence-changed`.
-*Run manifest*: the record of resolved refs, versions, and settings for one run. *Blast
-radius*: all finding diffs plus summary totals. *Hook binding point*: pre-triage, triage, or
-post-triage (§10).
+naming a finding across runs (§7). *Finding locator*: a reference to one occurrence in a
+specific report — report reference, identity, line (§7). *Diff class*: `new`, `dropped`, or
+`changed` (§8). *Run manifest*: the record of resolved refs, versions, environments, and
+settings for one run. *Blast radius*: all finding diffs plus summary totals. *Hook binding
+point*: pre-triage, triage, or post-triage (§10).
 
 ## 3. Operating model
 
 - The detector is obtained by cloning its repository and installing the base and head refs
   into two isolated cached virtualenvs (`uv pip` when on `PATH`, stdlib `venv` + `pip`
   fallback). Escape hatch: `--old-cmd`/`--new-cmd` point at pre-built executables.
-- Determinism: corpus refs are resolved once per run and then pinned (including
-  latest-on-branch mode); both detector revisions analyze byte-identical checkouts; resolved
-  SHAs are recorded in the run manifest; the analysis phase performs no network access
-  (network only during acquisition).
-- Cache: virtualenvs and checkouts live under the `platformdirs` cache directory, keyed by
-  (repository, resolved SHA), guarded by `filelock`.
+- Two-phase runs: an **acquisition** phase (git fetches, package installs) in which network
+  access is permitted and every fetch is recorded in the run manifest (URLs, resolved SHAs,
+  installed versions), followed by an **analysis** phase whose subprocesses run with
+  networking disabled (§11). Corpus refs are resolved once per run and then pinned
+  (including latest-on-branch mode); both detector revisions analyze byte-identical
+  checkouts.
+- Environment integrity: virtualenv cache entries under the `platformdirs` cache directory
+  are keyed by the full fingerprint (repository, resolved SHA, Python version and ABI,
+  platform tag, installer name and version) and guarded by `filelock`; checkout caches are
+  keyed by (repository, SHA). The manifest records the resolved dependency freeze of both
+  environments, and the report must surface any non-detector dependency delta between the
+  base and head environments as an explicit drift warning. `--fresh` forces same-run
+  rebuilds of both environments.
 - Concurrency: `asyncio` orchestrates per-project subprocesses with a configurable
   parallelism limit and a per-(project, tool) timeout.
 
 ## 4. Supported detectors
 
-- v1 adapters: `vulture`, `skylos`, `culler`, `mollify` (permissively licensed,
-  uv-installable, Python-focused, actively developed).
+- v1 adapters: `vulture` and `skylos` (pure Python, generic source-install path) in
+  Phase 1; `culler` and `mollify` (Rust/maturin builds requiring a declared toolchain) in
+  Phase 2. All four are permissively licensed, uv-installable, and actively developed.
 - Adapters implement a typed `Protocol`: raw invocation output → `list[Finding]`, declaring
-  capabilities (e.g. has-confidence, output format). The interface is not Python-specific
-  (paths plus optional symbol), leaving room for tools such as `knip`.
+  capabilities (e.g. has-confidence, output format) and a **build recipe** — build backend
+  plus toolchain prerequisites with minimum versions (e.g. Rust and maturin for `culler`
+  and `mollify`) — which the runner verifies before building and CI provisions for gated
+  detectors. The interface is not Python-specific (paths plus optional symbol), leaving
+  room for tools such as `knip`.
 - Future candidates (non-normative): `pydeadcode`, `dangle`, `deadpy`, `uncalled`, and
   subset-capability tools (ruff, mypy, pyright, CodeQL).
 - Licensing rule: GPL/AGPL detectors (e.g. `deadcode` AGPL-3.0, pylint GPL-2.0) may only
@@ -87,18 +99,24 @@ post-triage (§10).
   Minor versions are additive-only; breaking changes require a major bump.
 - `Finding` fields: tool, project, path (repo-relative POSIX), symbol (nullable), kind,
   message, line span, `confidence: int | None`, raw excerpt reference.
-- Finding identity: a stable hash over (tool, project name, path, symbol, kind) — excluding
-  line and confidence — with an ordinal disambiguating identical tuples. Identity is what
-  diffing matches on and what `bisect` accepts.
+- Finding identity: a stable hash over (tool, project name, path, symbol, kind), excluding
+  line and confidence. Identity carries no positional ordinal; a report holds a *multiset*
+  of occurrences (line span, message, confidence) per identity. Persistent references — the
+  `bisect` input in particular — use a *finding locator* (report reference, identity, line),
+  never a position-dependent key.
 
 ## 8. Diff engine
 
-- Both revisions see identical files, so matching is exact (identity, line) first, then
-  identity-only; results classify as `new`, `dropped`, or `confidence-changed` (the latter
-  only for tools declaring the confidence capability).
+- Both revisions see identical files. Matching is exact (identity, line) first, then
+  per-identity multiset reconciliation of the remaining occurrences; results classify as
+  `new`, `dropped`, or `changed`, where `changed` carries a
+  `changed_fields ⊆ {line-span, message, confidence}` set (confidence only for tools
+  declaring that capability). Every normalized observable field participates in the
+  comparison; no identity-stable behavior change may go silently unclassified.
 - Caps on maximum results and excerpt lines are configurable; the report always states
-  totals before truncation (new/dropped/changed counts, per project and overall) and notes
-  any truncation.
+  totals before truncation (new/dropped/changed counts, with confidence changes broken out,
+  per project and overall) and notes any truncation. Rendered reports cap message-only
+  changes to a count plus bounded examples; the JSON report retains full detail.
 
 ## 9. Reporting
 
@@ -129,10 +147,30 @@ post-triage (§10).
 
 ## 11. Security posture
 
-Defense-in-depth, not injection *detection*: excerpts are untrusted, sanitization is
-mandatory, and an optional deny-pattern pre-triage hook may veto ingesting an entire
-repository. All of this is documented as best-effort; no component claims to detect prompt
-injection reliably.
+- Trust boundary: user-authored configuration, hooks, and `--old-cmd`/`--new-cmd` are
+  trusted user code; corpus content — files, paths, and detector output derived from them —
+  is always untrusted.
+- Injection: defense-in-depth, not *detection* — excerpts are untrusted, sanitization is
+  mandatory, and an optional deny-pattern pre-triage hook may veto ingesting an entire
+  repository. All best-effort; no component claims to detect prompt injection reliably.
+- Subprocess hygiene: every subprocess launch uses an argv list with `shell=False`; every
+  argv element originates from typed, validated models; per-tool corpus commands are argv
+  lists, never shell strings; corpus content is never interpolated into any command; no
+  `eval`/`exec` of dynamic content anywhere. (ruff `ALL` includes the bandit rules —
+  S602/S604, S102/S307 — and AGENTS.md forbids `noqa`, so the linter mechanically enforces
+  this clause.)
+- Network isolation: analysis-phase subprocesses run with networking disabled (Linux network
+  namespaces or a container with `--network=none`), enforced on the Linux reference platform
+  and in CI, best-effort elsewhere. The manifest records whether isolation was enforced, and
+  reports flag unenforced runs. This also limits the blast radius of a malicious corpus
+  repository exploiting a detector parser bug.
+- Corpus code execution: the core (Phases 1–2) never executes corpus code — detectors only
+  parse it. Any workflow that executes corpus code (coverage evidence, runner files,
+  distillation; Phases 3–4) runs only inside an isolated container: no network, read-only
+  source mount, non-root, CPU/memory/time limits. The sole output channel is declared
+  artifact paths (e.g. coverage data), re-ingested as untrusted, schema-validated input.
+  Without a container runtime these features hard-fail; there is no host-execution
+  fallback.
 
 ## 12. CLI surface
 
@@ -140,11 +178,16 @@ injection reliably.
 
 - `run --tool T --repo URL --old REF --new REF [-k SEL | --all | --max-cost S]
   [--max-results N] [--excerpt-lines N] [--output text|json|github] [--fail-on ...]
-  [--old-cmd CMD --new-cmd CMD] [--project URL]`
+  [--fresh] [--old-cmd CMD --new-cmd CMD] [--project URL]`
 - `corpus validate` — parse and validate the corpus TOML.
 - `corpus license-check` — §6, locally or in CI.
-- `bisect --finding ID --tool T --good REF --bad REF` — binary search over detector commits,
-  building virtualenvs per step and running only the affected project.
+- `bisect --report REPORT.json --finding ID [--line N] --good REF --bad REF [--repo URL]
+  [--predicate P]` — binary search over detector commits. The prior report supplies the
+  manifest (detector repository, corpus pins), so every step reproduces the identical
+  checkout; the finding locator resolves the affected project, which is the only project
+  run. The predicate defaults from the finding's diff class in the report (`new` → first
+  commit where present; `dropped` → first where absent; confidence change → first where
+  confidence differs from base) and may be overridden.
 - `schema export` — regenerate `liveness_primer/schemas/`.
 
 ## 13. Internal corpus
@@ -154,7 +197,7 @@ injection reliably.
   `evidence: coverage | manual | llm-assisted | runner`, provenance (source project, commit,
   extraction date), and an optional runner link — a repo-relative path to a runner file
   (e.g. `corpus_runners/<name>.py`) that executably demonstrates the evidence in ambiguous
-  cases.
+  cases. Runner files execute only under the §11 container-isolation rules.
 - Rule: coverage evidence can only support `live`; absence of coverage yields `no-coverage`,
   never `dead`.
 
@@ -163,12 +206,15 @@ injection reliably.
 Phase 4. Only the schemas are contractually fixed now: §13 annotations plus provenance
 tracing every distilled entry to an approved corpus project. Workflows (tool-disagreement
 mining, finding-oscillation mining, interactive or LLM-assisted adversarial reproducers) are
-explicitly experimental and non-normative.
+explicitly experimental and non-normative. All corpus-code execution in distillation is
+subject to the §11 container-isolation rule.
 
 ## 15. Testing strategy (binding)
 
 - Testability by construction: no module-level side effects; git operations exercised
-  against `git init` throwaway repositories; no network in unit tests.
+  against `git init` throwaway repositories; no network in unit tests; sandbox and
+  container launchers are injectable so isolation logic is testable without real
+  containers.
 - Shipped test utilities: a fake detector able to produce any required output/diff
   characteristic between fake pinned "commits", and a fake project factory producing small
   synthetic projects with injected characteristics.
@@ -200,12 +246,14 @@ factory), `internal_corpus/`.
 
 ## 19. Phases and acceptance criteria
 
-1. **Core.** Corpus TOML and validation, the four v1 adapters, two-revision runner with
-   caching, diff engine, all three report modes, `corpus validate` and `license-check` CI,
-   schemas exported and sync-checked, initial corpus list chosen. Acceptance: an end-to-end
-   run against a real detector PR produces the expected structured diff, with full coverage.
-2. **Hooks and bisect.** The three binding points, subprocess bridge, sanitizer, and
-   `bisect`.
+1. **Core.** Corpus TOML and validation, the `vulture` and `skylos` adapters, two-revision
+   runner with fingerprint-keyed caching and enforced network isolation, diff engine, all
+   three report modes, `corpus validate` and `license-check` CI, schemas exported and
+   sync-checked, initial corpus list chosen. Acceptance: an end-to-end run against a real
+   detector PR produces the expected structured diff, with full coverage.
+2. **Hooks, bisect, native-build detectors.** The three binding points, subprocess bridge,
+   sanitizer, `bisect`, and the `culler` and `mollify` adapters via the build-recipe
+   mechanism with CI toolchain provisioning.
 3. **Internal corpus.** Annotation schema, initial manually annotated entries, runner-file
    evidence support.
 4. **Distillation (experimental).** §14 tooling.

--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -49,12 +49,12 @@ point*: pre-triage, triage, or post-triage (§10).
   Python version and ABI, platform tag, installer name and version) and guarded by
   `filelock`; checkout caches are keyed by (repository, SHA). The manifest records the
   resolved dependency freeze of both environments. A base/head pair is **comparable** iff
-  the non-detector dependency delta is empty or attributable to declared-requirement
-  differences between the two refs; a non-comparable pair triggers an automatic paired
-  same-run rebuild, after which any remaining delta is ref-attributable by construction and
-  reported as context. The manifest records a `comparable` flag; `--fail-on` gating and
-  `bisect` refuse to act on non-comparable runs. `--fresh` forces same-run rebuilds of both
-  environments.
+  the non-detector dependency delta is empty; any non-empty delta triggers an automatic
+  paired same-run rebuild, and only a delta that survives same-run paired resolution is
+  ref-attributable (reported as context). Attribution is temporal, never textual:
+  declared-requirement differences between the refs do not excuse a cached pair. The
+  manifest records a `comparable` flag; `--fail-on` gating and `bisect` refuse to act on
+  non-comparable runs. `--fresh` forces same-run rebuilds of both environments.
 - Concurrency: `asyncio` orchestrates per-project subprocesses with a configurable
   parallelism limit and a per-(project, tool) timeout.
 
@@ -118,15 +118,19 @@ point*: pre-triage, triage, or post-triage (§10).
 
 ## 8. Diff engine
 
-- Both revisions see identical files. Matching is deterministic and order-independent:
-  (1) full-field-equal occurrences are removed by multiset intersection; (2) remaining
-  occurrences sharing (identity, line) are paired in canonical sort order (message, then
-  confidence) as `changed`; (3) remaining occurrences sharing identity are paired across
-  lines in sorted-line order as `changed`; (4) leftovers classify as `new` or `dropped`.
-  `changed` carries a `changed_fields ⊆ {line-span, message, confidence}` set (confidence
-  only for tools declaring that capability). Every normalized observable field participates
-  in the comparison; no identity-stable behavior change may go silently unclassified, and
-  the canonical ordering makes reports reproducible.
+- Both revisions see identical files. Matching is deterministic and order-independent. The
+  **canonical occurrence key** is the complete normalized occurrence tuple in fixed field
+  order (start line, end line, message, confidence, plus any observable field added later);
+  it governs all sorting below and the report ordering that `--occurrence` indexes (§12).
+  Stages: (1) full-field-equal occurrences are removed by multiset intersection;
+  (2) remaining occurrences sharing (identity, start line) are paired in canonical-key
+  order as `changed`; (3) remaining occurrences sharing identity are paired across lines
+  in canonical-key order as `changed`; (4) leftovers classify as `new` or `dropped`. After
+  stage 1, canonical-key ties occur only between fully identical, interchangeable
+  occurrences. `changed` carries a `changed_fields ⊆ {line-span, message, confidence}` set
+  (confidence only for tools declaring that capability). Every normalized observable field
+  participates in the comparison; no identity-stable behavior change may go silently
+  unclassified.
 - Caps on maximum results and excerpt lines are configurable; the report always states
   totals before truncation (new/dropped/changed counts, with confidence changes broken out,
   per project and overall) and notes any truncation. Rendered reports cap message-only
@@ -204,12 +208,14 @@ printing the package version and `SCHEMA_VERSION`. Commands:
 - `bisect --report REPORT.json --finding ID [--line N] [--occurrence N] --good REF
   --bad REF [--repo URL] [--predicate P]` — binary search over detector commits. The prior
   report supplies the manifest (detector repository, corpus pins), so every step reproduces
-  the identical checkout; the finding locator resolves to a full base occurrence in the
-  report, and the affected project is the only project run. When several occurrences share
-  (identity, line), `--occurrence` indexes the report's canonical ordering (§8). Default
-  predicate by diff class: `new` → first commit where the occurrence is present; `dropped`
-  → first where absent; `changed` → first where the occurrence deviates from its base
-  value in any of the finding's `changed_fields`. `--predicate` overrides.
+  the identical checkout; the affected project is the only project run. The locator
+  resolves to a full occurrence on the diff class's **reference side** — head for `new`,
+  base for `dropped` and `changed` — and `--occurrence` indexes that side's canonical
+  ordering (§8) when several occurrences share (identity, line). Default predicate by diff
+  class: `new` → first commit where the head occurrence is present; `dropped` → first
+  where the base occurrence is absent; `changed` → first where the occurrence deviates
+  from its base-side values in any of the finding's `changed_fields`. `--predicate`
+  overrides.
 - `schema export` — regenerate `liveness_primer/schemas/`.
 
 ## 13. Internal corpus

--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -33,8 +33,9 @@ point*: pre-triage, triage, or post-triage (§10).
   fallback). Escape hatch: `--old-cmd`/`--new-cmd` point at pre-built executables.
 - Three-step runs: a **fetch** step (network permitted; git clones plus dependency prefetch
   into a local wheel cache, wheels preferred; detector-ref dependencies are resolved by
-  statically parsing PEP 621 `[project]` metadata — no build backend is invoked, so no code
-  from the detector refs executes; every fetch is recorded in the run manifest — URLs,
+  statically parsing `[project.dependencies]`/`[project.optional-dependencies]` and
+  `[build-system].requires` — no build backend is invoked, so no code from the detector
+  refs executes; every fetch is recorded in the run manifest — URLs,
   resolved SHAs, installed versions), then a **build** step (networking disabled per §11;
   the detector installs from the local cache, e.g. `--no-index --find-links`, so
   build-backend hooks run sandboxed; Rust detectors prefetch crates during fetch and build
@@ -76,8 +77,11 @@ point*: pre-triage, triage, or post-triage (§10).
   capabilities (e.g. has-confidence, output format) and a **build recipe** — build backend
   plus toolchain prerequisites with minimum versions (e.g. Rust and maturin for `culler`
   and `mollify`) — which the runner verifies before building and CI provisions for gated
-  detectors. v1 build recipes require static PEP 621 metadata (§3); dynamic-metadata
-  detectors are unsupported. Adapters ingest only dead-code finding kinds: other report
+  detectors. v1 build recipes require statically declared dependencies and build
+  requirements — `dependencies`/`optional-dependencies` must not be listed in `dynamic`
+  (§3); other fields such as `version` may be dynamic and resolve during the sandboxed
+  build (vulture's `dynamic = ["version"]` is fine). Detectors with dynamic dependency
+  metadata are unsupported. Adapters ingest only dead-code finding kinds: other report
   categories (e.g. skylos's security, secrets, and quality findings) are filtered at the
   adapter. The interface is not Python-specific (paths plus optional symbol), leaving room
   for tools such as `knip`.
@@ -165,8 +169,9 @@ point*: pre-triage, triage, or post-triage (§10).
   quoting so downstream LLM consumers structurally see them as data. Sanitization is
   mandatory and not hook-removable.
 - Exit codes: 0 for any successful run regardless of diff size; opt-in
-  `--fail-on {new,dropped,any,corpus-integrity}` gating; distinct nonzero codes for run
-  failure vs. gate failure.
+  `--fail-on {new,dropped,changed,any,corpus-integrity}` gating (repeatable; `any` covers
+  the three diff classes, not `corpus-integrity`); distinct nonzero codes for run failure
+  vs. gate failure.
 
 ## 10. Hook system
 

--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -1,19 +1,211 @@
-***Implementation contract for `liveness_primer`.***
+# Implementation contract for `liveness_primer`
 
-`liveness_primer` is a tool inspired by `mypy_primer` intended for use as an on-PR CI workflow run for dead code detectors like `vulture`, `skylos`, `pydeadcode`, etc. The core functionality is to run on a corpus of the files of existing open-source projects, and identify the *blast radius* of the PR by isolating the *diffs* in the dead code detector’s reports from before and after the commit, so that a human or llm reviewer can evaluate whether the blast radius is different or larger (or smaller) than expected. The *core* functionality is ***not*** to determine whether a diff is *correct*; a new finding could be a new false-positive or a newly recovered false-negative true, while a dropped finding could be either a new false negative or a dropped false positive. The maximum number of results and length of excerpts should be configurable, and the report should summarize the blast radius total number of reports/lines of diff including positive and negative changes. The report can be configurable between CI job, GitHub action, CLI, etc.
+`liveness_primer` is a `mypy_primer`-style tool for dead-code detectors. It runs a Python
+dead-code detector at two revisions — the base and head of a PR to the *detector* — against a
+fixed corpus of open-source projects, and reports the *blast radius*: the structured diff of
+the detector's findings, for human or LLM review.
 
-However, there must be extension hooks for triage functionality; specifically, there must be an extension hook/API binding point to run on the diffs before triage (e.g., hooks that perform normalization, or security rejection of malicious diffs attempting prompt injections from attacker controlled code, etc), an extension hook for triage itself (e.g., ranking individual diffs as on-target or off-target for the commit, ranking how likely changed behavior is intended, ranking importance for human review, etc; the triage system should be fully user specifiable, and could be a combination of algorithmic rankings and llm hooks depending on user preference). There should also be a binding for a post-triage hook, for, e.g., further normalization, dropping low priority findings, etc. Hooks should specify handoffs with a defined and versioned `json` schema. A default report is produced even if the hooks are all no-ops; the hooks add functionality. The diff communication should distinguish new or dropped findings from findings with changed confidence percentage, for dead code detection libraries which specify a changed confidence.
+## 1. Scope and non-goals
 
-It should specify a standardized format for adding projects to the corpus, like `mypy_primer/projects.py` including path,  configurable per-repository commands for each supported tool, paths, costs of different supported tools, included or excluded tools for that repository, the ability to either pin an analysis commit for a particular repository or use latest on a specified branch (and permit duplicating repositories to allow multiple pinned commit), the ability to specify whether a given tool is expected to be clean, and the license type for the project. Unlike `mypy_primer`, the project should specify the corpus projects via a human-readable `toml` file, which is then read into a machine-readable json-schema for checking and passing. Alternatively, a single target project can be specified with the CLI and default settings. All read-in parameters should be validated with pydantic, to fit the repositories typed usage. There should be a CI workflow which checks the license type of the target repository is truthful, and requires only a reasonable whitelist of licenses like mit, apache-2.0, etc, expressly vetoing e.g. any GPL licensed code or unlicensed code.
+v1 non-goals:
 
-The user should be able to key to specific supported projects to run against, all, or up to some specified maximum total estimated cost for the tool they are running with.
+- Adjudicating whether a diff is *correct*. A new finding may be a false positive or a
+  recovered false negative; a dropped finding may be either. The core reports the diff;
+  judgment belongs to reviewers and optional triage hooks.
+- Auto-fixing dead code.
+- Project-under-test mode (fixed detector, varying corpus revision). A possible future
+  extension; the corpus pin design must not preclude it, but v1 does not implement it.
 
-There should be a module to adapt the outputs of supported tools into an internal standardized json schema report, with e.g. pydantic validation as necessary, and potentially static/regex-based security detection of attempted prompt injection that can veto reading in an entire repo.
+## 2. Terminology
 
-In addition to scanning external projects, it should have an internal standard corpus. The standard corpus can define a json schema that allows annotations like ground-truth information about whether a given variable or line is dead.
+*Detector*: the dead-code tool under test. *Corpus project*: a repository the detector runs
+against. *Finding*: one normalized detector report item. *Finding identity*: the stable hash
+naming a finding across runs (§7). *Diff class*: `new`, `dropped`, or `confidence-changed`.
+*Run manifest*: the record of resolved refs, versions, and settings for one run. *Blast
+radius*: all finding diffs plus summary totals. *Hook binding point*: pre-triage, triage, or
+post-triage (§10).
 
-There should be a separate distillation functionality for building a compact and informative standard corpus; it could look for areas in external modules where the findings between different supported tools disagree, or where specified previous commit changes have produced notable diffs or oscillations in the findings of a particular tool. The procedure could be interactive, semi-automated (with human review), or use llm calls with specific injection hardened skills. The skill version could take diffs and attempt to adversarially generate similar reproducers that produce either true or false negatives.  The distillation can built its annotations for ground-truth liveness using e.g. coverage.py, spys, and monkeypatches, preferably using a narrow core set of functionality. Distilled corpus entries should have required metadata in the schema that traces them to the approved project they were distilled from.
+## 3. Operating model
 
-It should have a functionality to bisect which commit causes a change in a specified finding in the diff.
+- The detector is obtained by cloning its repository and installing the base and head refs
+  into two isolated cached virtualenvs (`uv pip` when on `PATH`, stdlib `venv` + `pip`
+  fallback). Escape hatch: `--old-cmd`/`--new-cmd` point at pre-built executables.
+- Determinism: corpus refs are resolved once per run and then pinned (including
+  latest-on-branch mode); both detector revisions analyze byte-identical checkouts; resolved
+  SHAs are recorded in the run manifest; the analysis phase performs no network access
+  (network only during acquisition).
+- Cache: virtualenvs and checkouts live under the `platformdirs` cache directory, keyed by
+  (repository, resolved SHA), guarded by `filelock`.
+- Concurrency: `asyncio` orchestrates per-project subprocesses with a configurable
+  parallelism limit and a per-(project, tool) timeout.
 
-All repository QA rules in AGENTS.md must be respected. Unit tests should cover all branches and edge cases and should be non-vacuous.
+## 4. Supported detectors
+
+- v1 adapters: `vulture`, `skylos`, `culler`, `mollify` (permissively licensed,
+  uv-installable, Python-focused, actively developed).
+- Adapters implement a typed `Protocol`: raw invocation output → `list[Finding]`, declaring
+  capabilities (e.g. has-confidence, output format). The interface is not Python-specific
+  (paths plus optional symbol), leaving room for tools such as `knip`.
+- Future candidates (non-normative): `pydeadcode`, `dangle`, `deadpy`, `uncalled`, and
+  subset-capability tools (ruff, mypy, pyright, CodeQL).
+- Licensing rule: GPL/AGPL detectors (e.g. `deadcode` AGPL-3.0, pylint GPL-2.0) may only
+  ever be invoked as separate subprocesses with parsed output — never vendored, linked, or
+  listed as dependencies (including optional). v1 ships no adapter for them.
+
+## 5. Corpus specification
+
+- The corpus is a human-authored TOML file parsed with `tomllib` and validated into pydantic
+  models (the source of truth); JSON Schema is exported from the models (§7).
+- Per-project fields: `name` (unique key; the same repository may appear under distinct
+  names to allow multiple pins), `repo` URL, `license` (SPDX ID), exactly one of `pin`
+  (commit SHA) or `branch` (latest-on-branch), and per-tool tables with command/argument
+  overrides, target paths, `expected_clean: bool`, declared `cost` in CPU-seconds
+  (approximate, reference runner; measured actuals are recorded in the report), and
+  include/exclude tool lists.
+- Ad-hoc mode: a single target repository given on the CLI with default settings.
+- Selection: by name (`-k`), `--all`, or `--max-cost SECONDS` (greedy under declared cost
+  for the chosen tool).
+- The initial corpus list is deferred to a Phase 1 task (~5–10 permissively licensed,
+  actively maintained, moderate-size projects).
+
+## 6. License verification
+
+- Corpus allowlist (SPDX): MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, PSF-2.0.
+  Copyleft (GPL/AGPL/LGPL/MPL) or missing license: hard fail. Unrecognized: human review.
+- A CI job on PRs touching the corpus file queries the GitHub license API per repository and
+  compares against the declared SPDX ID; mismatches fail the check. Detection is
+  advisory-strength (licensee is imperfect) but the check is binding in CI. Implemented with
+  `httpx` (the `[license]` extra) and runnable locally via `corpus license-check`.
+
+## 7. Schemas and finding identity
+
+- Models: `Finding`, `FindingOccurrence`, `RunManifest`, `Report`, `FindingDiff`,
+  `HookEnvelope`, `Annotation` (§13). Pydantic models are the source of truth; JSON Schema
+  files are exported into `liveness_primer/schemas/`; `schema export` regenerates them and a
+  CI check enforces that the files match the models.
+- A single package-wide `SCHEMA_VERSION` (semver) is embedded in every serialized payload.
+  Minor versions are additive-only; breaking changes require a major bump.
+- `Finding` fields: tool, project, path (repo-relative POSIX), symbol (nullable), kind,
+  message, line span, `confidence: int | None`, raw excerpt reference.
+- Finding identity: a stable hash over (tool, project name, path, symbol, kind) — excluding
+  line and confidence — with an ordinal disambiguating identical tuples. Identity is what
+  diffing matches on and what `bisect` accepts.
+
+## 8. Diff engine
+
+- Both revisions see identical files, so matching is exact (identity, line) first, then
+  identity-only; results classify as `new`, `dropped`, or `confidence-changed` (the latter
+  only for tools declaring the confidence capability).
+- Caps on maximum results and excerpt lines are configurable; the report always states
+  totals before truncation (new/dropped/changed counts, per project and overall) and notes
+  any truncation.
+
+## 9. Reporting
+
+- Output modes: CLI text, JSON (the full `Report`), and GitHub step summary (markdown).
+  PR-comment posting is out of core (requires a writable token); the JSON artifact is the
+  CI-consumable product.
+- Excerpts are untrusted data: length caps, control-character stripping, and fenced/escaped
+  quoting so downstream LLM consumers structurally see them as data. Sanitization is
+  mandatory and not hook-removable.
+- Exit codes: 0 for any successful run regardless of diff size; opt-in
+  `--fail-on {new,dropped,any}` gating; distinct nonzero codes for run failure vs. gate
+  failure.
+
+## 10. Hook system
+
+- Three binding points: **pre-triage** (normalization, security veto), **triage** (ranking —
+  algorithmic or LLM, fully user-supplied), **post-triage** (filtering, final
+  normalization). The default pipeline is all no-ops and still yields the full report.
+- Hooks are typed callables satisfying `@runtime_checkable` `Protocol`s, registered by
+  dotted path in configuration; payloads are the versioned schema models.
+- Failure semantics: pre-triage hooks fail closed (an exception vetoes the affected
+  repository or findings and is recorded). Triage and post-triage hooks fail open by default
+  (warning recorded in the report), unless they raise `TriageSafetyError`, which forces
+  fail-closed.
+- Shipped hooks: a subprocess bridge speaking the versioned JSON envelope over stdin/stdout
+  (language-agnostic hooks without making subprocess plumbing the primary API), and the
+  mandatory pre-triage excerpt sanitizer (§9).
+
+## 11. Security posture
+
+Defense-in-depth, not injection *detection*: excerpts are untrusted, sanitization is
+mandatory, and an optional deny-pattern pre-triage hook may veto ingesting an entire
+repository. All of this is documented as best-effort; no component claims to detect prompt
+injection reliably.
+
+## 12. CLI surface
+
+`argparse`. Commands:
+
+- `run --tool T --repo URL --old REF --new REF [-k SEL | --all | --max-cost S]
+  [--max-results N] [--excerpt-lines N] [--output text|json|github] [--fail-on ...]
+  [--old-cmd CMD --new-cmd CMD] [--project URL]`
+- `corpus validate` — parse and validate the corpus TOML.
+- `corpus license-check` — §6, locally or in CI.
+- `bisect --finding ID --tool T --good REF --bad REF` — binary search over detector commits,
+  building virtualenvs per step and running only the affected project.
+- `schema export` — regenerate `liveness_primer/schemas/`.
+
+## 13. Internal corpus
+
+- An in-repo annotated corpus with sidecar annotations. `Annotation` fields: target
+  (path/symbol/line), `verdict: live | dead | no-coverage | unknown`,
+  `evidence: coverage | manual | llm-assisted | runner`, provenance (source project, commit,
+  extraction date), and an optional runner link — a repo-relative path to a runner file
+  (e.g. `corpus_runners/<name>.py`) that executably demonstrates the evidence in ambiguous
+  cases.
+- Rule: coverage evidence can only support `live`; absence of coverage yields `no-coverage`,
+  never `dead`.
+
+## 14. Distillation (experimental)
+
+Phase 4. Only the schemas are contractually fixed now: §13 annotations plus provenance
+tracing every distilled entry to an approved corpus project. Workflows (tool-disagreement
+mining, finding-oscillation mining, interactive or LLM-assisted adversarial reproducers) are
+explicitly experimental and non-normative.
+
+## 15. Testing strategy (binding)
+
+- Testability by construction: no module-level side effects; git operations exercised
+  against `git init` throwaway repositories; no network in unit tests.
+- Shipped test utilities: a fake detector able to produce any required output/diff
+  characteristic between fake pinned "commits", and a fake project factory producing small
+  synthetic projects with injected characteristics.
+- Adapters are tested against recorded raw-output fixtures; the diff engine and reports
+  against golden files; hooks as pure functions.
+- All repository QA rules in AGENTS.md apply: full branch and line coverage with non-vacuous
+  tests, enforced by the existing coverage.py CI gate.
+
+## 16. Platform support
+
+POSIX-first; Linux CI is the reference platform. Windows is best-effort: nothing in the
+design intentionally blocks it, but it is not gated in CI initially.
+
+## 17. Dependencies
+
+- Runtime: `pydantic>=2`, `platformdirs>=4`, `filelock>=3`, `packaging>=24`.
+- Extras: `[license]` → `httpx` (license verification only).
+- Stdlib elsewhere: `tomllib`, `argparse`, `subprocess`/`venv`, `asyncio`. Git via
+  subprocess; `uv` used opportunistically, never required. Detectors are never dependencies
+  of this package.
+
+## 18. Package layout (informative)
+
+`cli.py`, `config.py` (corpus models), `corpus.py` (checkout and pin resolution),
+`envcache.py`, `runner.py`, `tools/` (adapter protocol plus one module per adapter),
+`findings.py`, `diffing.py`, `report/`, `hooks/` (protocols, `TriageSafetyError`, sanitizer,
+subprocess bridge), `schemas/`, `bisect.py`, `testing/` (fake detector, fake project
+factory), `internal_corpus/`.
+
+## 19. Phases and acceptance criteria
+
+1. **Core.** Corpus TOML and validation, the four v1 adapters, two-revision runner with
+   caching, diff engine, all three report modes, `corpus validate` and `license-check` CI,
+   schemas exported and sync-checked, initial corpus list chosen. Acceptance: an end-to-end
+   run against a real detector PR produces the expected structured diff, with full coverage.
+2. **Hooks and bisect.** The three binding points, subprocess bridge, sanitizer, and
+   `bisect`.
+3. **Internal corpus.** Annotation schema, initial manually annotated entries, runner-file
+   evidence support.
+4. **Distillation (experimental).** §14 tooling.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       # lower bound would test nothing useful.
       - name: Install project (${{ matrix.resolution }} resolution)
         run: |
-          uv vpython ${{ matrix.python-version }}
+          uv venv --python ${{ matrix.python-version }}
           uv pip install --resolution ${{ matrix.resolution }} .
           uv pip install pytest
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,35 @@
+"""Sphinx configuration for the `liveness_primer` HTML docs.
+
+Built locally with ``sphinx-build -b html docs docs/_build/html`` and in CI by
+.github/workflows/docs.yml, which additionally passes ``-W --keep-going`` so any
+warning (broken reference, stale docstring) fails the build.
+"""
+
+from importlib.metadata import version as _version
+
+project = 'liveness_primer'
+author = 'Matthew C. Digman'
+project_copyright = '2026, Matthew C. Digman'
+release = _version('liveness_primer')
+
+extensions = [
+    'myst_parser',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
+]
+
+templates_path: list[str] = []
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_theme = 'furo'
+html_static_path: list[str] = []
+
+# numpy-style docstrings, matching the [tool.pydoclint] style setting.
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# liveness_primer
+
+Primer for dead code detectors.
+
+This documentation is a placeholder while the implementation described in
+`.contracts/initial_contract.md` is being written. API reference pages will be
+added here as modules land.
+
+## Installation
+
+```bash
+pip install liveness_primer
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,10 @@ keywords = [
 ]
 
 dependencies = [
-    "pydantic",
+    "pydantic>=2",
     "platformdirs>=4",
     "filelock>=3",
     "packaging>=24",
-    "httpx>=0.28,<1",
 ]
 requires-python = ">=3.12"
 
@@ -45,6 +44,11 @@ Issues = "https://github.com/mcdigman/liveness_primer/issues"
 Changelog = "https://github.com/mcdigman/liveness_primer/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+# GitHub-API license verification (`corpus license-check` and its CI job);
+# see .contracts/initial_contract.md §6.
+license = [
+    "httpx>=0.28,<1",
+]
 dev = [
     "pytest>=7.0",
     "ruff",

--- a/ruff.toml
+++ b/ruff.toml
@@ -52,8 +52,29 @@ inline-quotes="single"
 author = "Matthew C. Digman"
 min-file-size = 1024
 
+[lint.flake8-tidy-imports.banned-api]
+# Contract §11 subprocess hygiene: every subprocess launch goes through the
+# audited launcher module, which accepts only typed argv lists and exposes no
+# shell parameter. The bandit S rules cannot enforce this on their own: S603
+# flags every subprocess call regardless of safety, and no S rule flags
+# asyncio.create_subprocess_shell.
+"subprocess.run".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"subprocess.Popen".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"subprocess.call".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"subprocess.check_call".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"subprocess.check_output".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"subprocess.getoutput".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"subprocess.getstatusoutput".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.system".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.popen".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"asyncio.create_subprocess_shell".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"asyncio.create_subprocess_exec".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+
 [lint.per-file-ignores]
 "tests/*" = ["S101", "D103"]
+# The audited launcher (contract §11) is the sole module allowed to touch the
+# raw subprocess APIs. S603 fires on every subprocess call, safe or not.
+"liveness_primer/launcher.py" = ["TID251", "S603"]
 
 [lint.pydocstyle]
 convention = "numpy"

--- a/ruff.toml
+++ b/ruff.toml
@@ -94,6 +94,10 @@ min-file-size = 1024
 
 [lint.per-file-ignores]
 "tests/*" = ["S101", "D103"]
+# Sphinx's conf.py is executed by sphinx-build, not imported as part of a
+# package, so it is deliberately not in one (INP001). Its module-level settings
+# are fixed names dictated by Sphinx.
+"docs/conf.py" = ["INP001"]
 # The audited launcher (contract §11) is the sole module allowed to touch the
 # raw subprocess APIs. S603 fires on every subprocess call, safe or not.
 "liveness_primer/launcher.py" = ["TID251", "S603"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -67,8 +67,30 @@ min-file-size = 1024
 "subprocess.getstatusoutput".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
 "os.system".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
 "os.popen".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execl".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execle".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execlp".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execlpe".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execv".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execve".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execvp".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.execvpe".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnl".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnle".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnlp".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnlpe".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnv".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnve".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnvp".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.spawnvpe".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.posix_spawn".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"os.posix_spawnp".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+"pty.spawn".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
 "asyncio.create_subprocess_shell".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
 "asyncio.create_subprocess_exec".msg = "Launch subprocesses only via the audited launcher module (contract §11)."
+# NOTE: event-loop instance methods (loop.subprocess_exec/loop.subprocess_shell)
+# cannot be banned by qualified name; the AST test required by contract §15 is
+# the backstop for those.
 
 [lint.per-file-ignores]
 "tests/*" = ["S101", "D103"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for `liveness_primer`."""

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,12 @@
+"""Smoke tests for the installed `liveness_primer` package.
+
+These keep the suite non-empty while the implementation is still being written:
+pytest exits 5 ("no tests collected") on an empty suite, which fails the Test
+and Coverage workflows regardless of whether anything is actually broken.
+"""
+
+import importlib
+
+
+def test_package_is_importable() -> None:
+    assert importlib.import_module('liveness_primer') is not None


### PR DESCRIPTION
## Summary

Reworks `.contracts/initial_contract.md` from a feature wishlist into a normative, phased implementation contract, per design discussion:

- **Operating model pinned down**: v1 is fixed-corpus / variable-detector (mypy_primer style) — clone the detector, build base/head refs into cached isolated venvs (`uv` opportunistic, `venv`+`pip` fallback), with `--old-cmd`/`--new-cmd` escape hatches; byte-identical corpus checkouts guaranteed for both revisions; asyncio concurrency.
- **v1 adapters named**: `vulture`, `skylos`, `culler`, `mollify`; typed adapter `Protocol`; GPL/AGPL detectors restricted to subprocess-only interaction and out of v1.
- **Schemas**: pydantic models as source of truth, exported JSON Schema with a package-wide semver `SCHEMA_VERSION`, and a stable finding-identity hash (excludes line/confidence) that diffing and `bisect` key on.
- **Hooks**: pre-triage / triage / post-triage `@runtime_checkable` Protocols; pre-triage fails closed, others fail open unless raising `TriageSafetyError`; shipped subprocess-JSON bridge and mandatory excerpt sanitizer.
- **Security reframed** from "prompt injection detection" to defense-in-depth: excerpts are untrusted data, sanitization non-removable, deny-pattern veto hook best-effort.
- **License verification**: SPDX allowlist (MIT, Apache-2.0, BSD-2/3-Clause, ISC, PSF-2.0), GitHub-API-backed CI check.
- **Internal corpus / distillation**: annotation schema fixed now (`live | dead | no-coverage | unknown`, evidence types, runner-file links; coverage can only ever prove `live`); distillation workflows explicitly experimental (Phase 4).
- **Binding testing strategy**: fake detector + fake project factory utilities, fixture/golden-file testing, no network in unit tests.
- **Four phases** with acceptance criteria; initial corpus list deferred to a Phase 1 task.

`pyproject.toml` updated to match the contract's dependency section: `httpx` moved to a new `[license]` extra, `pydantic>=2` floor added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)