### PR TITLE
Harden coverage and publish workflows; bump filelock floor

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,9 +56,13 @@ jobs:
       # (the branch being merged into); pushes fall back to github.ref_name. main
       # requires 100%, every other target uses the dev threshold. Then print the
       # report and fail the job if total coverage drops below that gate.
+      # The ref is passed through env rather than interpolated into the script,
+      # so a branch name containing shell metacharacters is compared, not run.
       - name: Coverage report
+        env:
+          TARGET_REF: ${{ github.base_ref || github.ref_name }}
         run: |
-          target="${{ github.base_ref || github.ref_name }}"
+          target="${TARGET_REF}"
           if [ "$target" = "main" ]; then
             thresh="${MAIN_COVERAGE}"
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,17 +24,20 @@ jobs:
     # Build the sdist + wheel once and hand them to whichever publish job runs,
     # so the artifacts uploaded to the index are exactly what was checked here.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
+      # The cache is deliberately off here, unlike the CI workflows: this job
+      # produces the artifacts that get published, and restoring mutable cache
+      # state into it would let a poisoned entry influence what ships.
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: "3.14"
-          cache-dependency-glob: "**/pyproject.toml"
 
       - name: Build sdist and wheel
         run: uv build
@@ -78,6 +81,8 @@ jobs:
     needs: build
     if: github.event.release.prerelease
     runs-on: ubuntu-latest
+    # Bound the runtime of a job holding publish credentials.
+    timeout-minutes: 10
     environment:
       name: testpypi
       url: https://test.pypi.org/p/liveness_primer
@@ -100,6 +105,8 @@ jobs:
     needs: build
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
+    # Bound the runtime of a job holding publish credentials.
+    timeout-minutes: 10
     environment:
       name: pypi
       url: https://pypi.org/p/liveness_primer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
 dependencies = [
     "pydantic>=2",
     "platformdirs>=4",
-    "filelock>=3",
+    "filelock>=3.20.3",
     "packaging>=24",
 ]
 requires-python = ">=3.12"


### PR DESCRIPTION
Closes #3.

Three hardening items in workflows that predate #2, plus one unrelated dependency bump carried along (see the last section).

### 1. `coverage.yml` no longer interpolates a context value into a `run:` block

The target ref now comes in through the step's `env:` and is read as `${TARGET_REF}`, so a branch name carrying shell metacharacters is compared rather than executed. This matches how the same step already reads `MAIN_COVERAGE` / `DEV_COVERAGE`.

### 2. `publish.yml` build job no longer restores the uv cache

`enable-cache: false` (and the now-unused `cache-dependency-glob` dropped). This is the job that produces the artifacts that ship, so mutable cache state has no business being restored into it. The CI workflows keep their caches — this is a release-path-only change, at the cost of a cold uv install on each release.

### 3. `publish.yml` privileged jobs get `timeout-minutes`

`build` gets 15, `testpypi` and `pypi` get 10 each, so a hung or compromised run cannot sit indefinitely holding publish credentials.

### 4. Unrelated: `filelock>=3.20.3` (CVE-2026-22701)

Cherry-picked from `phase1-core` so the fix reaches `main` without waiting on that branch. Not part of #3 — happy to split it out if you'd rather review it separately. Note this raises the floor that the `lowest-direct` resolution job installs.

### Verification

`actionlint` (via the prek hook) and YAML parsing both pass. The publish workflow itself only runs on a published Release, so items 2 and 3 are not exercised by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)