### PR TITLE
Build revision-scoped Skylos Go engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ liveness-primer run --tool vulture --project https://github.com/pytest-dev/plugg
 In CI, render the human report to the step summary and archive the JSON
 report — the CI-consumable product — from the same run:
 
+Managed Skylos comparisons build each revision's native Go engine when its
+source is present. Put Go 1.22 or newer on ``PATH`` first (for example with a
+SHA-pinned Go setup action in CI); builds are offline and never use an ambient
+``skylos-go`` binary.
+
 ```bash
 liveness-primer run --tool skylos --repo "$REPO" --old "$BASE" --new "$HEAD" \
   --all --output github --json-out liveness-primer-report.json \

--- a/liveness_primer/envcache.py
+++ b/liveness_primer/envcache.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import shutil
 import sys
 import sysconfig
@@ -24,7 +25,7 @@ import tomllib
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Protocol, TypeGuard, runtime_checkable
 
 from filelock import BaseFileLock, FileLock, Timeout
 from packaging.requirements import InvalidRequirement, Requirement
@@ -35,17 +36,19 @@ from packaging.utils import (
     parse_sdist_filename,
     parse_wheel_filename,
 )
+from packaging.version import InvalidVersion, Version
 
 from liveness_primer.corpus import CheckoutStore
 from liveness_primer.errors import LivenessPrimerError
 from liveness_primer.findings import DependencyDelta, EnvironmentRecord, FetchRecord
 from liveness_primer.isolation import UNENFORCED, Isolation, scrubbed_environment
 from liveness_primer.launcher import LaunchResult, SyncLauncher, run_sync, validate_sync_launcher
-from liveness_primer.tools.base import DetectorAdapter
+from liveness_primer.tools.base import DetectorAdapter, GoExecutableBuild
 
 _DEFAULT_BUILD_REQUIRES: tuple[str, ...] = ('setuptools>=40.8.0', 'wheel')
 
 _INSTALL_TIMEOUT = 1800.0
+_GO_VERSION_PATTERN = re.compile(r'\bgo(?P<version>[0-9]+(?:\.[0-9]+){1,2})\b')
 
 # Upper bound for the statically parsed pyproject.toml: real files are a few
 # KiB; anything larger is hostile or broken (contract §11 untrusted content).
@@ -58,6 +61,31 @@ class EnvCacheError(LivenessPrimerError):
 
 class UnsupportedDetectorError(EnvCacheError):
     """Raised for detectors violating the §4 static-metadata rule."""
+
+
+@dataclass(frozen=True, slots=True)
+class _GoToolchain:
+    """Resolved Go compiler used by one managed environment build."""
+
+    executable: str
+    identity: str
+
+
+@dataclass(frozen=True, slots=True)
+class _GoBuildPlan:
+    """Resolved revision-scoped Go build inputs."""
+
+    source: Path
+    recipe: GoExecutableBuild
+    toolchain: _GoToolchain
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedEnvironment:
+    """Validated private cache metadata for one managed environment."""
+
+    freeze: tuple[str, ...]
+    artifacts: tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -387,6 +415,135 @@ def _checked(result: LaunchResult, *, action: str) -> LaunchResult:
         msg = f'{action} failed: {detail}'
         raise EnvCacheError(msg)
     return result
+
+
+def _artifact_digest(path: Path) -> str:
+    """Hash one regular, non-symlink build artifact.
+
+    Parameters
+    ----------
+    path : Path
+        Artifact path.
+
+    Returns
+    -------
+    str
+        SHA-256 hex digest.
+
+    Raises
+    ------
+    EnvCacheError
+        If the path is not a regular file.
+    """
+    if path.is_symlink() or not path.is_file():
+        msg = f'build artifact is not a regular file: {path.name}'
+        raise EnvCacheError(msg)
+    digest = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1_048_576), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _go_source_directory(checkout: Path, build: GoExecutableBuild) -> Path | None:
+    """Resolve an optional Go module without following checkout symlinks.
+
+    Parameters
+    ----------
+    checkout : Path
+        Detector checkout.
+    build : GoExecutableBuild
+        Adapter-declared build specification.
+
+    Returns
+    -------
+    Path | None
+        Go module path, or ``None`` when the revision has no module.
+
+    Raises
+    ------
+    EnvCacheError
+        If the declared source is unsafe or malformed.
+    """
+    relative = build.source_dir
+    if not relative.parts or relative.is_absolute() or '..' in relative.parts:
+        msg = f'invalid Go build source directory: {relative.as_posix()!r}'
+        raise EnvCacheError(msg)
+    candidate = checkout
+    for part in relative.parts:
+        candidate /= part
+        if candidate.is_symlink():
+            msg = f'Go build source traverses a symlink: {relative.as_posix()}'
+            raise EnvCacheError(msg)
+    if not candidate.exists():
+        return None
+    if not candidate.is_dir():
+        msg = f'Go build source is not a directory: {relative.as_posix()}'
+        raise EnvCacheError(msg)
+    go_mod = candidate / 'go.mod'
+    if go_mod.is_symlink() or not go_mod.is_file():
+        msg = f'Go build source has no regular go.mod: {relative.as_posix()}'
+        raise EnvCacheError(msg)
+    return candidate
+
+
+def _resolve_go_toolchain(
+    build: GoExecutableBuild,
+    *,
+    launcher: SyncLauncher,
+    isolation: Isolation,
+) -> _GoToolchain:
+    """Resolve, validate, and identify the host Go compiler.
+
+    Parameters
+    ----------
+    build : GoExecutableBuild
+        Adapter-declared build specification.
+    launcher : SyncLauncher
+        Audited launcher for the version probe.
+    isolation : Isolation
+        Network isolation wrapper.
+
+    Returns
+    -------
+    _GoToolchain
+        Validated compiler path and cache identity.
+
+    Raises
+    ------
+    EnvCacheError
+        If Go is missing, invalid, or too old.
+    """
+    executable = shutil.which('go')
+    if executable is None:
+        msg = f'{build.executable} requires Go >= {build.minimum_version} on PATH'
+        raise EnvCacheError(msg)
+    resolved = Path(executable).resolve()
+    if not resolved.is_file():
+        msg = f'Go toolchain is not a regular file: {executable}'
+        raise EnvCacheError(msg)
+    with tempfile.TemporaryDirectory(prefix='liveness-primer-go-version-home-') as scratch_home:
+        env = scrubbed_environment(home=Path(scratch_home))
+        env['GOTOOLCHAIN'] = 'local'
+        result = _checked(
+            launcher(isolation.wrap([str(resolved), 'version']), env=env, timeout=60.0),
+            action='go version',
+        )
+    match = _GO_VERSION_PATTERN.search(result.stdout)
+    if match is None:
+        msg = f'could not parse Go version from {result.stdout.strip()!r}'
+        raise EnvCacheError(msg)
+    try:
+        version = Version(match.group('version'))
+        minimum = Version(build.minimum_version)
+    except InvalidVersion as exc:
+        msg = f'invalid Go toolchain version: {exc}'
+        raise EnvCacheError(msg) from exc
+    if version < minimum:
+        msg = f'{build.executable} requires Go >= {minimum}; found {version}'
+        raise EnvCacheError(msg)
+    identity = f'{result.stdout.strip()} sha256:{_artifact_digest(resolved)}'
+    return _GoToolchain(executable=str(resolved), identity=identity)
 
 
 @dataclass(frozen=True, slots=True)
@@ -789,7 +946,14 @@ def _fetch_records_for(wheelhouse: Path, added: Iterable[str]) -> tuple[FetchRec
     return tuple(records)
 
 
-def environment_fingerprint(repo: str, sha: str, adapter: DetectorAdapter, installer_identity: str) -> str:
+def environment_fingerprint(
+    repo: str,
+    sha: str,
+    adapter: DetectorAdapter,
+    installer_identity: str,
+    *,
+    toolchain_identity: str | None = None,
+) -> str:
     """Compute the full environment fingerprint (contract §3).
 
     Parameters
@@ -802,6 +966,8 @@ def environment_fingerprint(repo: str, sha: str, adapter: DetectorAdapter, insta
         Adapter supplying the build-recipe hash.
     installer_identity : str
         Installer name and version.
+    toolchain_identity : str | None
+        Native toolchain identity when the revision builds an artifact.
 
     Returns
     -------
@@ -818,25 +984,107 @@ def environment_fingerprint(repo: str, sha: str, adapter: DetectorAdapter, insta
             'abi': sysconfig.get_config_var('SOABI') or '',
             'platform': sysconfig.get_platform(),
             'installer': installer_identity,
+            'toolchain': toolchain_identity,
         },
         sort_keys=True,
     )
     return hashlib.sha256(material.encode('utf-8')).hexdigest()[:24]
 
 
-def _read_env_manifest(env_manifest: Path) -> tuple[str, ...] | None:
+def _is_str_list(value: object) -> TypeGuard[list[str]]:
+    """Check for a list containing only strings.
+
+    Parameters
+    ----------
+    value : object
+        Untrusted manifest value.
+
+    Returns
+    -------
+    TypeGuard[list[str]]
+        Whether the value is a string list.
+    """
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _is_str_dict(value: object) -> TypeGuard[dict[str, str]]:
+    """Check for a string-to-string dictionary.
+
+    Parameters
+    ----------
+    value : object
+        Untrusted manifest value.
+
+    Returns
+    -------
+    TypeGuard[dict[str, str]]
+        Whether the value is a string dictionary.
+    """
+    return isinstance(value, dict) and all(
+        isinstance(key, str) and isinstance(item, str) for key, item in value.items()
+    )
+
+
+def _validate_cached_artifacts(
+    env_dir: Path,
+    artifacts: Mapping[str, str],
+    expected_artifacts: tuple[str, ...],
+) -> tuple[tuple[str, str], ...] | None:
+    """Validate every cached artifact against its recorded digest.
+
+    Parameters
+    ----------
+    env_dir : Path
+        Managed environment directory.
+    artifacts : Mapping[str, str]
+        Manifest artifact paths and digests.
+    expected_artifacts : tuple[str, ...]
+        Artifact paths required by the build recipe.
+
+    Returns
+    -------
+    tuple[tuple[str, str], ...] | None
+        Validated artifact entries, or ``None`` on mismatch.
+    """
+    if set(artifacts) != set(expected_artifacts):
+        return None
+    validated: list[tuple[str, str]] = []
+    for relative, digest in sorted(artifacts.items()):
+        artifact = env_dir / relative
+        try:
+            actual_digest = _artifact_digest(artifact)
+        except (EnvCacheError, OSError):
+            return None
+        if not os.access(artifact, os.X_OK) or actual_digest != digest:
+            return None
+        validated.append((relative, digest))
+    return tuple(validated)
+
+
+def _read_env_manifest(
+    env_manifest: Path,
+    *,
+    fingerprint: str,
+    env_dir: Path,
+    expected_artifacts: tuple[str, ...],
+) -> _CachedEnvironment | None:
     """Read a cached environment manifest, tolerating corruption.
 
     Parameters
     ----------
     env_manifest : Path
         The per-environment manifest file.
+    fingerprint : str
+        Expected environment fingerprint.
+    env_dir : Path
+        Managed environment containing recorded artifacts.
+    expected_artifacts : tuple[str, ...]
+        Relative artifact paths required by this revision's recipe.
 
     Returns
     -------
-    tuple[str, ...] | None
-        The stored freeze, or ``None`` when absent or unusable (which
-        triggers a rebuild).
+    _CachedEnvironment | None
+        Validated metadata, or ``None`` when a rebuild is required.
     """
     if env_manifest.is_symlink() or not env_manifest.is_file():
         return None
@@ -844,15 +1092,17 @@ def _read_env_manifest(env_manifest: Path) -> tuple[str, ...] | None:
         stored = json.loads(env_manifest.read_text(encoding='utf-8'))
     except (OSError, ValueError):
         return None
-    if not isinstance(stored, dict):
+    if not isinstance(stored, dict) or stored.get('fingerprint') != fingerprint:
         return None
     freeze = stored.get('freeze')
-    if not isinstance(freeze, list) or any(not isinstance(line, str) for line in freeze):
+    artifacts = stored.get('artifacts')
+    if not _is_str_list(freeze) or not _is_str_dict(artifacts):
         return None
-    return tuple(freeze)
+    validated = _validate_cached_artifacts(env_dir, artifacts, expected_artifacts)
+    return None if validated is None else _CachedEnvironment(freeze=tuple(freeze), artifacts=validated)
 
 
-def _write_env_manifest(env_manifest: Path, fingerprint: str, freeze: tuple[str, ...]) -> None:
+def _write_env_manifest(env_manifest: Path, fingerprint: str, cached: _CachedEnvironment) -> None:
     """Atomically replace one environment manifest.
 
     Parameters
@@ -861,10 +1111,16 @@ def _write_env_manifest(env_manifest: Path, fingerprint: str, freeze: tuple[str,
         Destination manifest path.
     fingerprint : str
         Full environment fingerprint.
-    freeze : tuple[str, ...]
-        Installed distribution freeze.
+    cached : _CachedEnvironment
+        Installed distribution freeze and native-artifact digests.
     """
-    payload = json.dumps({'fingerprint': fingerprint, 'freeze': list(freeze)})
+    payload = json.dumps(
+        {
+            'fingerprint': fingerprint,
+            'freeze': list(cached.freeze),
+            'artifacts': dict(cached.artifacts),
+        }
+    )
     descriptor, temporary_name = tempfile.mkstemp(prefix='.liveness-primer-env-', dir=env_manifest.parent)
     temporary = Path(temporary_name)
     try:
@@ -887,11 +1143,14 @@ class EnvHandle:
         The virtualenv directory.
     executable : str
         Path to the detector console script.
+    runtime_env : tuple[tuple[str, str], ...]
+        Side-specific managed environment variables for analysis.
     """
 
     record: EnvironmentRecord
     env_dir: Path
     executable: str
+    runtime_env: tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -933,6 +1192,8 @@ class DetectorEnvironments:
         prefetch.
     isolation : Isolation
         Network isolation for build-step subprocesses (contract §11).
+    launcher : SyncLauncher
+        Audited launcher for native toolchain probes and builds.
     fresh : bool
         Force same-run rebuilds of both environments (``--fresh``).
     lock_timeout : float
@@ -946,6 +1207,7 @@ class DetectorEnvironments:
         *,
         installer: Installer,
         isolation: Isolation = UNENFORCED,
+        launcher: SyncLauncher = run_sync,
         fresh: bool = False,
         lock_timeout: float = _INSTALL_TIMEOUT,
     ) -> None:
@@ -953,6 +1215,8 @@ class DetectorEnvironments:
         self._cache_dir = cache_dir
         self._installer = installer
         self._isolation = isolation
+        validate_sync_launcher(launcher)
+        self._launcher = launcher
         self._fresh = fresh
         self._lock_timeout = lock_timeout
         self._fetches: list[FetchRecord] = []
@@ -1014,7 +1278,91 @@ class DetectorEnvironments:
             requirements.extend(metadata.build_requires)
         return self._prefetch(requirements)
 
-    def _build(self, fingerprint: str, checkout: Path, wheelhouse: Path) -> tuple[str, ...]:
+    def _build_go_executable(
+        self,
+        env_dir: Path,
+        source: Path,
+        build: GoExecutableBuild,
+        toolchain: _GoToolchain,
+        *,
+        env: Mapping[str, str],
+    ) -> tuple[str, str]:
+        """Build one revision-scoped Go executable into its environment.
+
+        Parameters
+        ----------
+        env_dir : Path
+            Managed environment receiving the executable.
+        source : Path
+            Validated detector-revision Go module.
+        build : GoExecutableBuild
+            Adapter-declared build specification.
+        toolchain : _GoToolchain
+            Validated Go compiler and its cache identity.
+        env : Mapping[str, str]
+            Scrubbed, credential-free base environment.
+
+        Returns
+        -------
+        tuple[str, str]
+            Environment-relative executable path and SHA-256 digest.
+        """
+        destination = Path(env_executable(env_dir, build.executable))
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f'.{build.executable}-', dir=destination.parent)
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        scratch = Path(env['HOME'])
+        build_env = dict(env)
+        build_env.update(
+            {
+                'CGO_ENABLED': '0',
+                'GOCACHE': str(scratch / 'go-build-cache'),
+                'GOMODCACHE': str(scratch / 'go-module-cache'),
+                'GOPATH': str(scratch / 'go-path'),
+                'GOPROXY': 'off',
+                'GOSUMDB': 'off',
+                'GOTOOLCHAIN': 'local',
+                'GOWORK': 'off',
+                'TMPDIR': str(scratch / 'tmp'),
+            }
+        )
+        Path(build_env['TMPDIR']).mkdir()
+        argv = [
+            toolchain.executable,
+            'build',
+            '-trimpath',
+            '-buildvcs=false',
+            '-mod=readonly',
+            '-o',
+            str(temporary),
+            build.package,
+        ]
+        try:
+            _checked(
+                self._launcher(
+                    self._isolation.wrap(argv),
+                    cwd=source,
+                    env=build_env,
+                    timeout=_INSTALL_TIMEOUT,
+                ),
+                action=f'build {build.executable}',
+            )
+            digest = _artifact_digest(temporary)
+            temporary.chmod(0o755)
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        relative = destination.relative_to(env_dir).as_posix()
+        return relative, digest
+
+    def _build(
+        self,
+        fingerprint: str,
+        checkout: Path,
+        wheelhouse: Path,
+        *,
+        go_plan: _GoBuildPlan | None,
+    ) -> _CachedEnvironment:
         """Build one environment: venv, offline sandboxed install, freeze.
 
         Every build-step subprocess runs under the §11 sandbox with a
@@ -1028,11 +1376,13 @@ class DetectorEnvironments:
             Detector checkout to install.
         wheelhouse : Path
             Prefetched wheel cache both sides install from.
+        go_plan : _GoBuildPlan | None
+            Resolved native build inputs, when this revision has them.
 
         Returns
         -------
-        tuple[str, ...]
-            The freeze of the built environment.
+        _CachedEnvironment
+            The freeze and native-artifact digests of the built environment.
         """
         env_dir = self._cache_dir / 'envs' / Path(fingerprint).name
         if env_dir.exists():
@@ -1041,35 +1391,49 @@ class DetectorEnvironments:
             env = scrubbed_environment(home=Path(scratch_home))
             self._installer.create_venv(env_dir, isolation=self._isolation, env=env)
             self._installer.install_offline(env_dir, wheelhouse, checkout, isolation=self._isolation, env=env)
-        return self._installer.freeze(env_dir)
+            artifacts: tuple[tuple[str, str], ...] = ()
+            if go_plan is not None:
+                artifacts = (
+                    self._build_go_executable(
+                        env_dir,
+                        go_plan.source,
+                        go_plan.recipe,
+                        go_plan.toolchain,
+                        env=env,
+                    ),
+                )
+        return _CachedEnvironment(freeze=self._installer.freeze(env_dir), artifacts=artifacts)
 
     def _ensure(
         self,
         *,
-        repo: str,
         ref: str,
         sha: str,
+        checkout: Path,
         adapter: DetectorAdapter,
         fingerprint: str,
         wheelhouse: Callable[[], Path],
+        go_plan: _GoBuildPlan | None,
         force_rebuild: bool,
     ) -> EnvHandle:
         """Return a cached environment or build it; the caller holds its lock.
 
         Parameters
         ----------
-        repo : str
-            Detector repository URL.
         ref : str
             Ref as requested on the CLI.
         sha : str
             Resolved commit SHA.
+        checkout : Path
+            Materialized detector revision.
         adapter : DetectorAdapter
             Adapter for recipe, distribution, and executable names.
         fingerprint : str
             Full environment fingerprint of this ref.
         wheelhouse : Callable[[], Path]
             Lazy provider of the pair's prefetched wheelhouse.
+        go_plan : _GoBuildPlan | None
+            Resolved native build inputs, when this revision has them.
         force_rebuild : bool
             Skip cache reuse and rebuild.
 
@@ -1080,33 +1444,56 @@ class DetectorEnvironments:
         """
         env_dir = self._cache_dir / 'envs' / Path(fingerprint).name
         env_manifest = env_dir / 'liveness-primer-env.json'
-        cached_freeze = None if force_rebuild else _read_env_manifest(env_manifest)
-        if cached_freeze is not None:
+        go_build = adapter.build_recipe.go_executable
+        expected_artifacts: tuple[str, ...] = ()
+        if go_plan is not None:
+            expected_artifacts = (
+                Path(env_executable(env_dir, go_plan.recipe.executable)).relative_to(env_dir).as_posix(),
+            )
+        cached = (
+            None
+            if force_rebuild
+            else _read_env_manifest(
+                env_manifest,
+                fingerprint=fingerprint,
+                env_dir=env_dir,
+                expected_artifacts=expected_artifacts,
+            )
+        )
+        if cached is not None:
             record = EnvironmentRecord(
                 ref=ref,
                 sha=sha,
                 fingerprint=fingerprint,
-                freeze=cached_freeze,
+                freeze=cached.freeze,
                 from_cache=True,
                 rebuilt=False,
             )
         else:
             house = wheelhouse()
-            checkout = self._store.materialize(repo, sha)
-            freeze = self._build(fingerprint, checkout, house)
-            _write_env_manifest(env_manifest, fingerprint, freeze)
+            cached = self._build(
+                fingerprint,
+                checkout,
+                house,
+                go_plan=go_plan,
+            )
+            _write_env_manifest(env_manifest, fingerprint, cached)
             record = EnvironmentRecord(
                 ref=ref,
                 sha=sha,
                 fingerprint=fingerprint,
-                freeze=freeze,
+                freeze=cached.freeze,
                 from_cache=False,
                 rebuilt=True,
             )
+        runtime_env = (
+            () if go_build is None else ((go_build.runtime_env, env_executable(env_dir, go_build.executable)),)
+        )
         return EnvHandle(
             record=record,
             env_dir=env_dir,
             executable=env_executable(env_dir, adapter.executable),
+            runtime_env=runtime_env,
         )
 
     def _acquire_locks(self, stack: contextlib.ExitStack, fingerprints: Iterable[str]) -> None:
@@ -1168,8 +1555,36 @@ class DetectorEnvironments:
         if head_sha != base_sha:
             self._fetches.append(FetchRecord(kind='git', name=repo, resolved=head_sha))
         installer_identity = self._installer.identity()
-        base_fingerprint = environment_fingerprint(repo, base_sha, adapter, installer_identity)
-        head_fingerprint = environment_fingerprint(repo, head_sha, adapter, installer_identity)
+        base_checkout = self._store.materialize(repo, base_sha)
+        head_checkout = base_checkout if head_sha == base_sha else self._store.materialize(repo, head_sha)
+        go_build = adapter.build_recipe.go_executable
+        base_go_plan: _GoBuildPlan | None = None
+        head_go_plan: _GoBuildPlan | None = None
+        if go_build is not None:
+            base_go_source = _go_source_directory(base_checkout, go_build)
+            head_go_source = _go_source_directory(head_checkout, go_build)
+            if base_go_source is not None or head_go_source is not None:
+                go_toolchain = _resolve_go_toolchain(go_build, launcher=self._launcher, isolation=self._isolation)
+                if base_go_source is not None:
+                    base_go_plan = _GoBuildPlan(base_go_source, go_build, go_toolchain)
+                if head_go_source is not None:
+                    head_go_plan = _GoBuildPlan(head_go_source, go_build, go_toolchain)
+        base_toolchain_identity = None if base_go_plan is None else base_go_plan.toolchain.identity
+        head_toolchain_identity = None if head_go_plan is None else head_go_plan.toolchain.identity
+        base_fingerprint = environment_fingerprint(
+            repo,
+            base_sha,
+            adapter,
+            installer_identity,
+            toolchain_identity=base_toolchain_identity,
+        )
+        head_fingerprint = environment_fingerprint(
+            repo,
+            head_sha,
+            adapter,
+            installer_identity,
+            toolchain_identity=head_toolchain_identity,
+        )
         (self._cache_dir / 'envs').mkdir(parents=True, exist_ok=True)
         wheelhouse: Path | None = None
 
@@ -1189,21 +1604,23 @@ class DetectorEnvironments:
         with contextlib.ExitStack() as stack:
             self._acquire_locks(stack, (base_fingerprint, head_fingerprint))
             base = self._ensure(
-                repo=repo,
                 ref=base_ref,
                 sha=base_sha,
+                checkout=base_checkout,
                 adapter=adapter,
                 fingerprint=base_fingerprint,
                 wheelhouse=pair_wheelhouse,
+                go_plan=base_go_plan,
                 force_rebuild=self._fresh,
             )
             head = self._ensure(
-                repo=repo,
                 ref=head_ref,
                 sha=head_sha,
+                checkout=head_checkout,
                 adapter=adapter,
                 fingerprint=head_fingerprint,
                 wheelhouse=pair_wheelhouse,
+                go_plan=head_go_plan,
                 force_rebuild=self._fresh,
             )
             delta = dependency_delta(
@@ -1215,21 +1632,23 @@ class DetectorEnvironments:
                 # Attribution is temporal, never textual: rebuild both sides
                 # in this run before attributing the delta to the refs (§3).
                 base = self._ensure(
-                    repo=repo,
                     ref=base_ref,
                     sha=base_sha,
+                    checkout=base_checkout,
                     adapter=adapter,
                     fingerprint=base_fingerprint,
                     wheelhouse=pair_wheelhouse,
+                    go_plan=base_go_plan,
                     force_rebuild=True,
                 )
                 head = self._ensure(
-                    repo=repo,
                     ref=head_ref,
                     sha=head_sha,
+                    checkout=head_checkout,
                     adapter=adapter,
                     fingerprint=head_fingerprint,
                     wheelhouse=pair_wheelhouse,
+                    go_plan=head_go_plan,
                     force_rebuild=True,
                 )
                 delta = dependency_delta(

--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -410,6 +410,7 @@ class PrimerRunner:
         *,
         side: str,
         command: tuple[str, ...],
+        runtime_env: tuple[tuple[str, str], ...],
         semaphore: asyncio.Semaphore,
     ) -> _SideOutcome:
         """Run the detector once on one side of one project (analysis step, §3).
@@ -422,6 +423,8 @@ class PrimerRunner:
             ``base`` or ``head``.
         command : tuple[str, ...]
             Detector command prefix for this side.
+        runtime_env : tuple[tuple[str, str], ...]
+            Side-specific managed environment variables.
         semaphore : asyncio.Semaphore
             The ``--jobs`` limiter.
 
@@ -440,6 +443,7 @@ class PrimerRunner:
             try:
                 environment = scrubbed_environment(home=workspace.home)
                 environment.update(self._adapter.invocation_env)
+                environment.update(runtime_env)
                 try:
                     async with asyncio.timeout(timeout):
                         result = await self._async_launcher(
@@ -530,6 +534,8 @@ class PrimerRunner:
         semaphore: asyncio.Semaphore,
         base_command: tuple[str, ...],
         head_command: tuple[str, ...],
+        base_runtime_env: tuple[tuple[str, str], ...],
+        head_runtime_env: tuple[tuple[str, str], ...],
     ) -> ProjectReport:
         """Analyze one project on both sides and diff the outcomes.
 
@@ -543,6 +549,10 @@ class PrimerRunner:
             Base detector command prefix.
         head_command : tuple[str, ...]
             Head detector command prefix.
+        base_runtime_env : tuple[tuple[str, str], ...]
+            Managed environment variables for the base side.
+        head_runtime_env : tuple[tuple[str, str], ...]
+            Managed environment variables for the head side.
 
         Returns
         -------
@@ -550,8 +560,24 @@ class PrimerRunner:
             The per-project slice of the blast radius.
         """
         async with asyncio.TaskGroup() as group:
-            base_task = group.create_task(self._invoke(item, side='base', command=base_command, semaphore=semaphore))
-            head_task = group.create_task(self._invoke(item, side='head', command=head_command, semaphore=semaphore))
+            base_task = group.create_task(
+                self._invoke(
+                    item,
+                    side='base',
+                    command=base_command,
+                    runtime_env=base_runtime_env,
+                    semaphore=semaphore,
+                )
+            )
+            head_task = group.create_task(
+                self._invoke(
+                    item,
+                    side='head',
+                    command=head_command,
+                    runtime_env=head_runtime_env,
+                    semaphore=semaphore,
+                )
+            )
         return self._project_report(item, base_task.result(), head_task.result())
 
     async def _analyze_all(
@@ -560,6 +586,8 @@ class PrimerRunner:
         *,
         base_command: tuple[str, ...],
         head_command: tuple[str, ...],
+        base_runtime_env: tuple[tuple[str, str], ...],
+        head_runtime_env: tuple[tuple[str, str], ...],
     ) -> tuple[ProjectReport, ...]:
         """Fan analysis out over projects under the jobs limit (contract §3).
 
@@ -571,6 +599,10 @@ class PrimerRunner:
             Base detector command prefix.
         head_command : tuple[str, ...]
             Head detector command prefix.
+        base_runtime_env : tuple[tuple[str, str], ...]
+            Managed environment variables for the base side.
+        head_runtime_env : tuple[tuple[str, str], ...]
+            Managed environment variables for the head side.
 
         Returns
         -------
@@ -586,6 +618,8 @@ class PrimerRunner:
                         semaphore=semaphore,
                         base_command=base_command,
                         head_command=head_command,
+                        base_runtime_env=base_runtime_env,
+                        head_runtime_env=head_runtime_env,
                     )
                 )
                 for item in work
@@ -687,7 +721,13 @@ class PrimerRunner:
         with environments.prepare_pair(detector_repo, base_ref, head_ref, self._adapter) as pair:
             work, corpus_fetches = self._fetch_corpus(projects)
             project_reports = asyncio.run(
-                self._analyze_all(work, base_command=(pair.base.executable,), head_command=(pair.head.executable,))
+                self._analyze_all(
+                    work,
+                    base_command=(pair.base.executable,),
+                    head_command=(pair.head.executable,),
+                    base_runtime_env=pair.base.runtime_env,
+                    head_runtime_env=pair.head.runtime_env,
+                )
             )
         manifest = self._manifest(
             detector_repo=detector_repo,
@@ -727,7 +767,13 @@ class PrimerRunner:
         """
         work, corpus_fetches = self._fetch_corpus(projects)
         project_reports = asyncio.run(
-            self._analyze_all(work, base_command=tuple(base_cmd), head_command=tuple(head_cmd))
+            self._analyze_all(
+                work,
+                base_command=tuple(base_cmd),
+                head_command=tuple(head_cmd),
+                base_runtime_env=(),
+                head_runtime_env=(),
+            )
         )
         manifest = self._manifest(
             detector_repo=None,

--- a/liveness_primer/tools/base.py
+++ b/liveness_primer/tools/base.py
@@ -63,6 +63,31 @@ class ToolchainRequirement:
 
 
 @dataclass(frozen=True, slots=True)
+class GoExecutableBuild:
+    """One Go executable built from a detector revision.
+
+    Attributes
+    ----------
+    source_dir : PurePosixPath
+        Checkout-relative Go module directory.
+    package : str
+        Go package passed to ``go build``.
+    executable : str
+        Output executable name inside the managed environment.
+    runtime_env : str
+        Environment variable receiving the managed executable path.
+    minimum_version : str
+        Minimum supported Go toolchain version.
+    """
+
+    source_dir: PurePosixPath
+    package: str
+    executable: str
+    runtime_env: str
+    minimum_version: str
+
+
+@dataclass(frozen=True, slots=True)
 class BuildRecipe:
     """Build recipe an adapter declares (contract §4).
 
@@ -72,10 +97,13 @@ class BuildRecipe:
         Build path; ``python-source`` is the generic source-install path.
     toolchain : tuple[ToolchainRequirement, ...]
         Toolchain prerequisites the runner verifies before building.
+    go_executable : GoExecutableBuild | None
+        Revision-scoped Go executable to build when its source is present.
     """
 
     backend: str
     toolchain: tuple[ToolchainRequirement, ...] = ()
+    go_executable: GoExecutableBuild | None = None
 
     def digest(self) -> str:
         """Hash the recipe for the environment-cache fingerprint (contract §3).
@@ -89,6 +117,17 @@ class BuildRecipe:
             {
                 'backend': self.backend,
                 'toolchain': [[entry.name, entry.minimum_version] for entry in self.toolchain],
+                'go_executable': (
+                    None
+                    if self.go_executable is None
+                    else {
+                        'source_dir': self.go_executable.source_dir.as_posix(),
+                        'package': self.go_executable.package,
+                        'executable': self.go_executable.executable,
+                        'runtime_env': self.go_executable.runtime_env,
+                        'minimum_version': self.go_executable.minimum_version,
+                    }
+                ),
             },
             sort_keys=True,
         )

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -10,7 +10,7 @@ when a corpus config opts into the matching analysis (contract §4, §5).
 
 import json
 from collections.abc import Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -20,6 +20,7 @@ from liveness_primer.tools.base import (
     AdapterCapabilities,
     AdapterError,
     BuildRecipe,
+    GoExecutableBuild,
     RawToolOutput,
     normalize_finding_path,
 )
@@ -157,7 +158,16 @@ class SkylosAdapter:
         has_severity=True,
         output_format='json',
     )
-    build_recipe: BuildRecipe = BuildRecipe(backend='python-source')
+    build_recipe: BuildRecipe = BuildRecipe(
+        backend='python-source',
+        go_executable=GoExecutableBuild(
+            source_dir=PurePosixPath('skylos/engines/go'),
+            package='./cmd/skylos-go',
+            executable='skylos-go',
+            runtime_env='SKYLOS_GO_BIN',
+            minimum_version='1.22',
+        ),
+    )
 
     @staticmethod
     def parse(output: RawToolOutput, *, project: str, root: Path, analyses: tuple[str, ...] = ()) -> list[Finding]:

--- a/tests/test_envcache.py
+++ b/tests/test_envcache.py
@@ -8,7 +8,7 @@ import sys
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import cast
 
 import pytest
@@ -33,6 +33,8 @@ from liveness_primer.filesystem import atomic_write_bytes, atomic_write_text
 from liveness_primer.findings import DependencyDelta
 from liveness_primer.isolation import UNENFORCED, Isolation
 from liveness_primer.launcher import LauncherError, LaunchResult, SyncLauncher, run_async, run_sync
+from liveness_primer.tools.base import BuildRecipe, GoExecutableBuild
+from liveness_primer.tools.skylos import SkylosAdapter
 from liveness_primer.tools.vulture import VultureAdapter
 
 PYPROJECT = """
@@ -168,6 +170,13 @@ def test_environment_fingerprint_varies_by_inputs() -> None:
     assert base != environment_fingerprint('https://other', 'a' * 40, adapter, 'pip 25.0')
     assert base != environment_fingerprint('https://r', 'b' * 40, adapter, 'pip 25.0')
     assert base != environment_fingerprint('https://r', 'a' * 40, adapter, 'uv 0.9')
+    assert base != environment_fingerprint(
+        'https://r',
+        'a' * 40,
+        adapter,
+        'pip 25.0',
+        toolchain_identity='go version go1.22.3',
+    )
 
 
 @dataclass
@@ -359,6 +368,30 @@ def detector_repo(tmp_path: Path) -> DetectorRepo:
     return DetectorRepo(url=repo_dir.as_uri(), path=repo_dir)
 
 
+@pytest.fixture
+def go_detector_repo(tmp_path: Path) -> DetectorRepo:
+    repo_dir = tmp_path / 'go-detector-origin'
+    repo_dir.mkdir()
+    git('init', '--quiet', str(repo_dir))
+    git('symbolic-ref', 'HEAD', 'refs/heads/base-branch', cwd=repo_dir)
+    git('config', 'user.email', 'test@example.invalid', cwd=repo_dir)
+    git('config', 'user.name', 'Test', cwd=repo_dir)
+    write_pyproject(repo_dir)
+    go_module = repo_dir / 'skylos' / 'engines' / 'go'
+    (go_module / 'cmd' / 'skylos-go').mkdir(parents=True)
+    atomic_write_text(go_module / 'go.mod', 'module example.invalid/skylos-go\n\ngo 1.22\n')
+    main = go_module / 'cmd' / 'skylos-go' / 'main.go'
+    atomic_write_text(main, 'package main\n// base revision\nfunc main() {}\n')
+    git('add', 'pyproject.toml', 'skylos', cwd=repo_dir)
+    git('commit', '--quiet', '-m', 'base', cwd=repo_dir)
+    git('checkout', '--quiet', '-b', 'head-branch', cwd=repo_dir)
+    write_pyproject(repo_dir, PYPROJECT.replace('tomli>=2', 'tomli>=2.1'))
+    atomic_write_text(main, 'package main\n// head revision\nfunc main() {}\n')
+    git('add', 'pyproject.toml', 'skylos', cwd=repo_dir)
+    git('commit', '--quiet', '-m', 'head', cwd=repo_dir)
+    return DetectorRepo(url=repo_dir.as_uri(), path=repo_dir)
+
+
 @dataclass
 class FakeInstaller:
     """Scripted installer that fabricates environments without pip."""
@@ -400,7 +433,7 @@ class FakeInstaller:
         """Create the environment directory like a real venv would."""
         del isolation
         self.events.append('create')
-        env_dir.mkdir(parents=True)
+        (env_dir / 'bin').mkdir(parents=True)
         self.created.append(env_dir)
         self.build_envs.append(env)
 
@@ -431,12 +464,68 @@ class FakeInstaller:
         return self.freezes.popleft()
 
 
+@dataclass
+class GoLauncher:
+    """Fake Go launcher that emits revision-distinct executable bytes."""
+
+    version: str = 'go version go1.22.3 test/arch\n'
+    version_returncode: int = 0
+    build_returncode: int = 0
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+    directories: list[Path | None] = field(default_factory=list)
+    envs: list[Mapping[str, str] | None] = field(default_factory=list)
+
+    def __call__(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> LaunchResult:
+        """Record a Go probe or materialize its requested build output.
+
+        Returns
+        -------
+        LaunchResult
+            Scripted toolchain result.
+        """
+        del timeout
+        command = tuple(argv)
+        self.calls.append(command)
+        self.directories.append(cwd)
+        self.envs.append(env)
+        is_version = command[-1] == 'version'
+        returncode = self.version_returncode if is_version else self.build_returncode
+        if not is_version and returncode == 0:
+            assert cwd is not None
+            output = Path(command[command.index('-o') + 1])
+            source = cwd / 'cmd' / 'skylos-go' / 'main.go'
+            output.write_bytes(source.read_bytes())
+        return LaunchResult(
+            argv=command,
+            returncode=returncode,
+            stdout=self.version if is_version else '',
+            stderr='go failed' if returncode else '',
+            duration_seconds=0.0,
+            timed_out=False,
+        )
+
+
+@dataclass(slots=True)
+class GoTestAdapter(VultureAdapter):
+    """Vulture-compatible test adapter with a configurable Go build."""
+
+    build_recipe: BuildRecipe
+
+
 def environments(
     tmp_path: Path,
     installer: FakeInstaller,
     *,
     fresh: bool = False,
     lock_timeout: float | None = None,
+    launcher: SyncLauncher = run_sync,
 ) -> DetectorEnvironments:
     store = CheckoutStore(tmp_path / 'cache')
     extra: dict[str, float] = {} if lock_timeout is None else {'lock_timeout': lock_timeout}
@@ -445,6 +534,7 @@ def environments(
         tmp_path / 'cache',
         installer=installer,
         isolation=SANDBOX,
+        launcher=launcher,
         fresh=fresh,
         **extra,
     )
@@ -453,6 +543,319 @@ def environments(
 FREEZE_A = ('vulture @ file:///x', 'tomli==2.4.0')
 FREEZE_B = ('vulture @ file:///y', 'tomli==2.4.0')
 FREEZE_BUMPED = ('vulture @ file:///y', 'tomli==2.5.0')
+SKYLOS_FREEZE_A = ('skylos @ file:///x', 'tomli==2.4.0')
+SKYLOS_FREEZE_B = ('skylos @ file:///y', 'tomli==2.4.0')
+
+
+def _fake_go_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    compiler = tmp_path / 'fake-go'
+    compiler.write_bytes(b'fake compiler')
+    compiler.chmod(0o755)
+    monkeypatch.setattr(shutil, 'which', lambda name: str(compiler) if name == 'go' else None)
+    return compiler
+
+
+def test_skylos_builds_revision_scoped_go_executables(
+    tmp_path: Path,
+    go_detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiler = _fake_go_on_path(tmp_path, monkeypatch)
+    monkeypatch.setenv('LP_PLANTED_SECRET', 'do-not-copy')
+    monkeypatch.setenv('SKYLOS_GO_BIN', '/ambient/skylos-go')
+    launcher = GoLauncher()
+    installer = FakeInstaller(freezes=deque([SKYLOS_FREEZE_A, SKYLOS_FREEZE_B]))
+
+    with environments(tmp_path, installer, launcher=launcher).prepare_pair(
+        go_detector_repo.url,
+        'base-branch',
+        'head-branch',
+        SkylosAdapter(),
+    ) as pair:
+        base_binary = Path(dict(pair.base.runtime_env)['SKYLOS_GO_BIN'])
+        head_binary = Path(dict(pair.head.runtime_env)['SKYLOS_GO_BIN'])
+        assert base_binary.read_bytes() != head_binary.read_bytes()
+        assert b'base revision' in base_binary.read_bytes()
+        assert b'head revision' in head_binary.read_bytes()
+        assert base_binary.parent == pair.base.env_dir / 'bin'
+        assert head_binary.parent == pair.head.env_dir / 'bin'
+
+    version_call, base_build, head_build = launcher.calls
+    assert version_call == ('sandbox-wrap', str(compiler), 'version')
+    for build_call in (base_build, head_build):
+        assert build_call[:3] == ('sandbox-wrap', str(compiler), 'build')
+        assert '-trimpath' in build_call
+        assert '-buildvcs=false' in build_call
+        assert '-mod=readonly' in build_call
+        assert build_call[-1] == './cmd/skylos-go'
+    for build_env in launcher.envs[1:]:
+        assert build_env is not None
+        assert 'LP_PLANTED_SECRET' not in build_env
+        assert 'SKYLOS_GO_BIN' not in build_env
+        assert build_env['GOPROXY'] == 'off'
+        assert build_env['GOSUMDB'] == 'off'
+        assert build_env['GOTOOLCHAIN'] == 'local'
+        assert build_env['GOWORK'] == 'off'
+        assert build_env['CGO_ENABLED'] == '0'
+        assert build_env['GOCACHE'].startswith(build_env['HOME'])
+        assert build_env['GOMODCACHE'].startswith(build_env['HOME'])
+        assert build_env['GOPATH'].startswith(build_env['HOME'])
+        assert build_env['TMPDIR'].startswith(build_env['HOME'])
+    assert pair.base.record.fingerprint != pair.head.record.fingerprint
+    manifest = json.loads((pair.base.env_dir / 'liveness-primer-env.json').read_text(encoding='utf-8'))
+    assert list(manifest['artifacts']) == ['bin/skylos-go']
+
+
+@pytest.mark.parametrize('corruption', ['missing', 'symlink', 'non-executable', 'content', 'manifest'])
+def test_skylos_rebuilds_a_corrupt_cached_go_executable(
+    tmp_path: Path,
+    go_detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+    corruption: str,
+) -> None:
+    _fake_go_on_path(tmp_path, monkeypatch)
+    first_launcher = GoLauncher()
+    first = FakeInstaller(freezes=deque([SKYLOS_FREEZE_A, SKYLOS_FREEZE_B]))
+    with environments(tmp_path, first, launcher=first_launcher).prepare_pair(
+        go_detector_repo.url,
+        'base-branch',
+        'head-branch',
+        SkylosAdapter(),
+    ) as primed:
+        pass
+    binary = Path(dict(primed.base.runtime_env)['SKYLOS_GO_BIN'])
+    manifest_path = primed.base.env_dir / 'liveness-primer-env.json'
+    if corruption == 'missing':
+        binary.unlink()
+    elif corruption == 'symlink':
+        binary.unlink()
+        binary.symlink_to(tmp_path / 'outside')
+    elif corruption == 'non-executable':
+        binary.chmod(0o644)
+    elif corruption == 'content':
+        binary.write_bytes(b'tampered')
+    else:
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+        manifest['artifacts'] = dict[str, str]()
+        manifest_path.write_text(json.dumps(manifest), encoding='utf-8')
+
+    second_launcher = GoLauncher()
+    second = FakeInstaller(freezes=deque([SKYLOS_FREEZE_A]))
+    with environments(tmp_path, second, launcher=second_launcher).prepare_pair(
+        go_detector_repo.url,
+        'base-branch',
+        'head-branch',
+        SkylosAdapter(),
+    ) as pair:
+        pass
+    assert pair.base.record.rebuilt
+    assert pair.head.record.from_cache
+    assert b'base revision' in Path(dict(pair.base.runtime_env)['SKYLOS_GO_BIN']).read_bytes()
+    assert len(second_launcher.calls) == 2
+
+
+def test_skylos_without_engine_source_never_uses_an_ambient_binary(
+    tmp_path: Path,
+    detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(shutil, 'which', lambda _name: None)
+    installer = FakeInstaller(freezes=deque([SKYLOS_FREEZE_A]))
+    with environments(tmp_path, installer).prepare_pair(
+        detector_repo.url,
+        'base-branch',
+        'base-branch',
+        SkylosAdapter(),
+    ) as pair:
+        managed = Path(dict(pair.base.runtime_env)['SKYLOS_GO_BIN'])
+    assert managed == pair.base.env_dir / 'bin' / 'skylos-go'
+    assert not managed.exists()
+
+
+def test_skylos_handles_engine_added_or_removed_between_revisions(
+    tmp_path: Path,
+    go_detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_go_on_path(tmp_path, monkeypatch)
+    origin = go_detector_repo.path
+    git('checkout', '--quiet', '-b', 'without-engine', cwd=origin)
+    shutil.rmtree(origin / 'skylos')
+    git('add', '--all', cwd=origin)
+    git('commit', '--quiet', '-m', 'remove engine', cwd=origin)
+
+    first = FakeInstaller(freezes=deque([SKYLOS_FREEZE_A, SKYLOS_FREEZE_B]))
+    with environments(tmp_path, first, launcher=GoLauncher()).prepare_pair(
+        go_detector_repo.url,
+        'base-branch',
+        'without-engine',
+        SkylosAdapter(),
+    ) as removed:
+        pass
+    assert Path(dict(removed.base.runtime_env)['SKYLOS_GO_BIN']).is_file()
+    assert not Path(dict(removed.head.runtime_env)['SKYLOS_GO_BIN']).exists()
+
+    second = FakeInstaller(freezes=deque())
+    with environments(tmp_path, second, launcher=GoLauncher()).prepare_pair(
+        go_detector_repo.url,
+        'without-engine',
+        'base-branch',
+        SkylosAdapter(),
+    ) as added:
+        pass
+    assert not Path(dict(added.base.runtime_env)['SKYLOS_GO_BIN']).exists()
+    assert Path(dict(added.head.runtime_env)['SKYLOS_GO_BIN']).is_file()
+    assert added.base.record.from_cache
+    assert added.head.record.from_cache
+
+
+def _go_build(*, source_dir: str = 'engine', minimum_version: str = '1.22') -> GoExecutableBuild:
+    return GoExecutableBuild(
+        source_dir=PurePosixPath(source_dir),
+        package='./cmd/tool',
+        executable='tool-go',
+        runtime_env='TOOL_GO_BIN',
+        minimum_version=minimum_version,
+    )
+
+
+def _go_adapter(*, source_dir: str = 'engine', minimum_version: str = '1.22') -> GoTestAdapter:
+    return GoTestAdapter(
+        build_recipe=BuildRecipe(
+            backend='python-source',
+            go_executable=_go_build(source_dir=source_dir, minimum_version=minimum_version),
+        )
+    )
+
+
+@pytest.mark.parametrize('source_dir', ['', '/absolute', '../escape', 'engine/../escape'])
+def test_go_source_directory_rejects_unsafe_paths(
+    tmp_path: Path,
+    detector_repo: DetectorRepo,
+    source_dir: str,
+) -> None:
+    installer = FakeInstaller(freezes=deque())
+    with (
+        pytest.raises(EnvCacheError, match='invalid Go build source'),
+        environments(tmp_path, installer).prepare_pair(
+            detector_repo.url,
+            'base-branch',
+            'head-branch',
+            _go_adapter(source_dir=source_dir),
+        ),
+    ):
+        pass
+
+
+def test_go_source_directory_rejects_symlinks_and_malformed_modules(
+    tmp_path: Path,
+    detector_repo: DetectorRepo,
+) -> None:
+    origin = detector_repo.path
+    (origin / 'outside').mkdir()
+    (origin / 'outside' / 'go.mod').write_text('module outside\n', encoding='utf-8')
+    (origin / 'engine-link').symlink_to('outside')
+    (origin / 'engine-file').write_text('not a directory', encoding='utf-8')
+    (origin / 'engine-empty').mkdir()
+    (origin / 'engine-empty' / 'marker').write_text('tracked', encoding='utf-8')
+    (origin / 'engine-mod-link').mkdir()
+    (origin / 'engine-mod-link' / 'go.mod').symlink_to('../outside/go.mod')
+    git('add', '--all', cwd=origin)
+    git('commit', '--quiet', '-m', 'malformed engines', cwd=origin)
+
+    for source_dir, match in (
+        ('engine-link', 'traverses a symlink'),
+        ('engine-file', 'is not a directory'),
+        ('engine-empty', r'no regular go\.mod'),
+        ('engine-mod-link', r'no regular go\.mod'),
+    ):
+        installer = FakeInstaller(freezes=deque())
+        with (
+            pytest.raises(EnvCacheError, match=match),
+            environments(tmp_path, installer).prepare_pair(
+                detector_repo.url,
+                'head-branch',
+                'head-branch',
+                _go_adapter(source_dir=source_dir),
+            ),
+        ):
+            pass
+
+
+@pytest.mark.parametrize(
+    ('version', 'minimum', 'match'),
+    [
+        ('unexpected output\n', '1.22', 'could not parse'),
+        ('go version go1.22.3 test/arch\n', 'not-a-version', 'invalid Go toolchain version'),
+        ('go version go1.21.9 test/arch\n', '1.22', 'requires Go >= 1.22'),
+    ],
+)
+def test_go_toolchain_rejects_invalid_versions(
+    tmp_path: Path,
+    go_detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+    version: str,
+    minimum: str,
+    match: str,
+) -> None:
+    _fake_go_on_path(tmp_path, monkeypatch)
+    installer = FakeInstaller(freezes=deque())
+    with (
+        pytest.raises(EnvCacheError, match=match),
+        environments(tmp_path, installer, launcher=GoLauncher(version=version)).prepare_pair(
+            go_detector_repo.url,
+            'base-branch',
+            'head-branch',
+            _go_adapter(source_dir='skylos/engines/go', minimum_version=minimum),
+        ),
+    ):
+        pass
+
+
+def test_go_toolchain_requires_a_regular_working_compiler(
+    tmp_path: Path,
+    go_detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for compiler, launcher, match in (
+        (None, GoLauncher(), r'requires Go >= 1\.22 on PATH'),
+        (str(tmp_path), GoLauncher(), 'not a regular file'),
+        (str(_fake_go_on_path(tmp_path, monkeypatch)), GoLauncher(version_returncode=1), 'go version failed'),
+    ):
+        monkeypatch.setattr(shutil, 'which', lambda _name, result=compiler: result)
+        installer = FakeInstaller(freezes=deque())
+        with (
+            pytest.raises(EnvCacheError, match=match),
+            environments(tmp_path, installer, launcher=launcher).prepare_pair(
+                go_detector_repo.url,
+                'base-branch',
+                'head-branch',
+                _go_adapter(source_dir='skylos/engines/go'),
+            ),
+        ):
+            pass
+
+
+def test_go_build_failure_does_not_install_a_partial_binary(
+    tmp_path: Path,
+    go_detector_repo: DetectorRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_go_on_path(tmp_path, monkeypatch)
+    launcher = GoLauncher(build_returncode=1)
+    installer = FakeInstaller(freezes=deque())
+    with (
+        pytest.raises(EnvCacheError, match='build skylos-go failed'),
+        environments(tmp_path, installer, launcher=launcher).prepare_pair(
+            go_detector_repo.url,
+            'base-branch',
+            'head-branch',
+            SkylosAdapter(),
+        ),
+    ):
+        pass
+    env_dirs = tuple((tmp_path / 'cache' / 'envs').glob('*'))
+    assert all(not (entry / 'bin' / 'skylos-go').exists() for entry in env_dirs if entry.is_dir())
 
 
 def test_cold_cache_builds_both_and_records_fetches(tmp_path: Path, detector_repo: DetectorRepo) -> None:
@@ -622,7 +1025,17 @@ def test_corrupt_env_manifest_triggers_rebuild(tmp_path: Path, detector_repo: De
     ) as primed:
         pass
     manifest = primed.base.env_dir / 'liveness-primer-env.json'
-    for corrupt in ('not json', '[1]', '{"other": 1}', '{"freeze": "nope"}', '{"freeze": [1]}'):
+    valid = json.loads(manifest.read_text(encoding='utf-8'))
+    corrupt_manifests = (
+        'not json',
+        '[1]',
+        json.dumps({**valid, 'fingerprint': 'wrong'}),
+        json.dumps({**valid, 'freeze': 'nope'}),
+        json.dumps({**valid, 'freeze': [1]}),
+        json.dumps({**valid, 'artifacts': 'nope'}),
+        json.dumps({**valid, 'artifacts': {'bin/tool': 1}}),
+    )
+    for corrupt in corrupt_manifests:
         manifest.write_text(corrupt, encoding='utf-8')
         again = FakeInstaller(freezes=deque([FREEZE_A]))
         with environments(tmp_path, again).prepare_pair(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,18 +3,19 @@
 """Tests for the two-revision runner over the fake detector (contract §3, §15)."""
 
 import asyncio
+import contextlib
 import re
 import sys
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import cast
+from typing import cast, override
 
 import pytest
 
 from liveness_primer.config import CorpusProject, ToolSettings
 from liveness_primer.corpus import CheckoutStore
-from liveness_primer.envcache import DetectorEnvironments
+from liveness_primer.envcache import DetectorEnvironments, PreparedPair
 from liveness_primer.filesystem import atomic_write_text, read_small_text
 from liveness_primer.findings import ChangedField, DiffClass, DiffRollup, DiffTotals, Report
 from liveness_primer.isolation import UNENFORCED, Isolation
@@ -23,6 +24,7 @@ from liveness_primer.report import render_github, render_text
 from liveness_primer.report.terminal import TextRenderOptions
 from liveness_primer.runner import PrimerRunner, RunnerError, RunOptions, evaluate_gates, report_has_failures
 from liveness_primer.testing import FakeFinding, create_fake_project, write_fake_detector_script
+from liveness_primer.tools.base import DetectorAdapter
 from liveness_primer.tools.registry import get_adapter
 
 BASE_FINDING = FakeFinding(path='pkg/mod.py', line=5, symbol='unused_helper', kind='function', confidence=60)
@@ -373,6 +375,33 @@ class ScriptedEnvInstaller:
         return ('vulture @ file:///fake',)
 
 
+class RuntimeEnvDetectorEnvironments(DetectorEnvironments):
+    """Test provider that supplies distinct managed variables per side."""
+
+    @contextlib.contextmanager
+    @override
+    def prepare_pair(
+        self,
+        repo: str,
+        base_ref: str,
+        head_ref: str,
+        adapter: DetectorAdapter,
+    ) -> Iterator[PreparedPair]:
+        """Add side-specific runtime variables to a prepared pair.
+
+        Yields
+        ------
+        PreparedPair
+            Pair carrying distinct test values.
+        """
+        with super().prepare_pair(repo, base_ref, head_ref, adapter) as pair:
+            yield replace(
+                pair,
+                base=replace(pair.base, runtime_env=(('SKYLOS_GO_BIN', '/managed/base/skylos-go'),)),
+                head=replace(pair.head, runtime_env=(('SKYLOS_GO_BIN', '/managed/head/skylos-go'),)),
+            )
+
+
 MINIMAL_DETECTOR_PYPROJECT = '[build-system]\nrequires = []\n\n[project]\nname = "vulture"\nversion = "9.9"\n'
 
 
@@ -565,14 +594,38 @@ def test_analysis_runs_with_a_scrubbed_environment(
         assert 'liveness-primer-side-' in env['HOME']
 
 
-def test_managed_run_end_to_end(tmp_path: Path, corpus_project: CorpusProject, fake_detector_repo: str) -> None:
+def test_managed_run_end_to_end(
+    tmp_path: Path,
+    corpus_project: CorpusProject,
+    fake_detector_repo: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('SKYLOS_GO_BIN', '/ambient/skylos-go')
+    captured: list[Mapping[str, str] | None] = []
+
+    async def spying_launcher(
+        argv: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> LaunchResult:
+        captured.append(env)
+        return await run_async(list(argv), cwd=cwd, env=env)
+
     installer = ScriptedEnvInstaller()
-    environments = DetectorEnvironments(
+    environments = RuntimeEnvDetectorEnvironments(
         CheckoutStore(tmp_path / 'cache'),
         tmp_path / 'cache',
         installer=installer,
     )
-    report = runner_for(tmp_path).run_managed(
+    runner = PrimerRunner(
+        adapter=get_adapter('vulture'),
+        store=CheckoutStore(tmp_path / 'cache'),
+        isolation=UNENFORCED,
+        options=DEFAULT_OPTIONS,
+        async_launcher=spying_launcher,
+    )
+    report = runner.run_managed(
         [corpus_project],
         detector_repo=fake_detector_repo,
         base_ref='base-branch',
@@ -591,6 +644,10 @@ def test_managed_run_end_to_end(tmp_path: Path, corpus_project: CorpusProject, f
     assert manifest.base_cmd is None
     assert report.totals == DiffTotals(new=2, dropped=1)
     assert not report_has_failures(report)
+    assert {env['SKYLOS_GO_BIN'] for env in captured if env is not None} == {
+        '/managed/base/skylos-go',
+        '/managed/head/skylos-go',
+    }
     git_fetches = [record for record in manifest.fetches if record.kind == 'git']
     assert fake_detector_repo in {record.name for record in git_fetches}
     assert corpus_project.repo in {record.name for record in git_fetches}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,7 +6,7 @@ Adapters are tested against recorded raw-output fixtures.
 """
 
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -16,6 +16,7 @@ from liveness_primer.tools.base import (
     AdapterError,
     BuildRecipe,
     DetectorAdapter,
+    GoExecutableBuild,
     RawToolOutput,
     ToolchainRequirement,
     UnknownToolError,
@@ -50,8 +51,19 @@ def test_registry_rejects_unknown_tools() -> None:
 def test_build_recipe_digest_is_stable_and_content_sensitive() -> None:
     plain = BuildRecipe(backend='python-source')
     rust = BuildRecipe(backend='maturin', toolchain=(ToolchainRequirement(name='rust', minimum_version='1.74'),))
+    go = BuildRecipe(
+        backend='python-source',
+        go_executable=GoExecutableBuild(
+            source_dir=PurePosixPath('engine'),
+            package='./cmd/tool',
+            executable='tool-go',
+            runtime_env='TOOL_GO_BIN',
+            minimum_version='1.22',
+        ),
+    )
     assert plain.digest() == BuildRecipe(backend='python-source').digest()
     assert plain.digest() != rust.digest()
+    assert plain.digest() != go.digest()
 
 
 def test_build_invocation_defaults() -> None:


### PR DESCRIPTION
## Summary

- build Skylos's native `skylos-go` engine from each detector revision into that revision's managed virtualenv
- pass the absolute, side-specific binary through `SKYLOS_GO_BIN`, preventing fallback to an ambient executable
- require Go 1.22+, fingerprint the compiler, build offline with a scrubbed environment, and validate cached artifact digests
- preserve comparisons with Skylos revisions that do not contain the Go engine

## Verification

- `prek run --all-files --show-diff-on-failure --color=never`
- 571 tests passed, 3 skipped
- 100% combined line and branch coverage
- `mypy liveness_primer tests`
- `pyright`
- `pydoclint liveness_primer`
