### PR TITLE
Retain partial findings from failed detector runs

### DIFF
--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -238,9 +238,10 @@ class _SideOutcome:
     side : str
         ``base`` or ``head``.
     findings : tuple[Finding, ...] | None
-        Parsed findings; ``None`` when the invocation failed.
+        Parsed findings, including usable partial failure output; ``None``
+        when no usable output was available.
     error : ToolError | None
-        The failure, when the invocation failed.
+        The invocation or output-parsing failure, when present.
     duration_seconds : float
         Wall-clock duration of the invocation.
     returncode : int | None
@@ -487,16 +488,18 @@ class PrimerRunner:
         _SideOutcome
             The parsed outcome.
         """
+        error: ToolError | None = None
         if result.returncode not in self._adapter.success_exit_codes:
             detail = f'exit code {result.returncode}: {result.stderr.strip()[-_STDERR_SNIPPET:]}'
             error = ToolError(side=side, exit_code=result.returncode, detail=detail)
-            return _SideOutcome(
-                side=side,
-                findings=None,
-                error=error,
-                duration_seconds=result.duration_seconds,
-                returncode=result.returncode,
-            )
+            if not result.stdout.strip():
+                return _SideOutcome(
+                    side=side,
+                    findings=None,
+                    error=error,
+                    duration_seconds=result.duration_seconds,
+                    returncode=result.returncode,
+                )
         raw = RawToolOutput(
             returncode=result.returncode if result.returncode is not None else 0,
             stdout=result.stdout,
@@ -505,7 +508,8 @@ class PrimerRunner:
         try:
             findings = self._adapter.parse(raw, project=item.project.name, root=root, analyses=item.settings.analyses)
         except AdapterError as exc:
-            error = ToolError(side=side, exit_code=result.returncode, detail=str(exc))
+            detail = str(exc) if error is None else f'{error.detail}; output parse failed: {exc}'
+            error = ToolError(side=side, exit_code=result.returncode, detail=detail)
             return _SideOutcome(
                 side=side,
                 findings=None,
@@ -516,7 +520,7 @@ class PrimerRunner:
         return _SideOutcome(
             side=side,
             findings=tuple(findings),
-            error=None,
+            error=error,
             duration_seconds=result.duration_seconds,
             returncode=result.returncode,
         )

--- a/liveness_primer/testing/fake_detector.py
+++ b/liveness_primer/testing/fake_detector.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Literal
 
 from liveness_primer.filesystem import atomic_write_text
-from liveness_primer.tools.skylos import DIAGNOSTIC_KINDS
+from liveness_primer.tools.skylos import BUCKET_RULE_IDS, DIAGNOSTIC_KINDS
 
 FakeFormat = Literal['vulture', 'skylos']
 
@@ -266,7 +266,7 @@ def _emit_skylos(findings: Sequence[FakeFinding]) -> int:
     int
         The default skylos exit code: 0.
     """
-    document: dict[str, list[dict[str, object]]] = {}
+    document: dict[str, list[dict[str, object]]] = {key: [] for key in BUCKET_RULE_IDS}
     for finding in findings:
         document.setdefault(finding.bucket, []).append(finding.skylos_entry())
     sys.stdout.write(json.dumps(document, indent=2) + '\n')

--- a/liveness_primer/tools/base.py
+++ b/liveness_primer/tools/base.py
@@ -171,7 +171,7 @@ class DetectorAdapter(Protocol):
         Parameters
         ----------
         output : RawToolOutput
-            Captured detector output with a success exit code.
+            Captured detector output, possibly from a failed invocation.
         project : str
             Corpus project name to stamp onto findings.
         root : Path

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -195,7 +195,8 @@ class SkylosAdapter:
         ------
         AdapterError
             If stdout is not a JSON object, an entry is malformed, or an
-            analysis is not declared.
+            analysis is not declared. Failed output must also contain a
+            recognized result bucket.
         """
         selected: set[str] = set()
         for name in analyses:
@@ -211,8 +212,14 @@ class SkylosAdapter:
         if not isinstance(document, dict):
             msg = 'skylos output is not a JSON object'
             raise AdapterError(msg)
+        result_keys = (*_DEAD_CODE_KEYS, *(bucket for bucket in DIAGNOSTIC_KINDS if bucket in selected))
+        if output.returncode not in SkylosAdapter.success_exit_codes and not any(
+            key in document for key in result_keys
+        ):
+            msg = 'failed skylos output has no recognized result bucket'
+            raise AdapterError(msg)
         findings: list[Finding] = []
-        for key in (*_DEAD_CODE_KEYS, *(bucket for bucket in DIAGNOSTIC_KINDS if bucket in selected)):
+        for key in result_keys:
             bucket = document.get(key, [])
             if not isinstance(bucket, list):
                 msg = f'skylos key {key!r} is not an array'

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -195,8 +195,8 @@ class SkylosAdapter:
         ------
         AdapterError
             If stdout is not a JSON object, an entry is malformed, or an
-            analysis is not declared. Failed output must also contain a
-            recognized result bucket.
+            analysis is not declared. Failed output must also produce at
+            least one finding from a recognized result bucket.
         """
         selected: set[str] = set()
         for name in analyses:
@@ -213,11 +213,6 @@ class SkylosAdapter:
             msg = 'skylos output is not a JSON object'
             raise AdapterError(msg)
         result_keys = (*_DEAD_CODE_KEYS, *(bucket for bucket in DIAGNOSTIC_KINDS if bucket in selected))
-        if output.returncode not in SkylosAdapter.success_exit_codes and not any(
-            key in document for key in result_keys
-        ):
-            msg = 'failed skylos output has no recognized result bucket'
-            raise AdapterError(msg)
         findings: list[Finding] = []
         for key in result_keys:
             bucket = document.get(key, [])
@@ -226,6 +221,9 @@ class SkylosAdapter:
                 raise AdapterError(msg)
             parse_entry = _parse_diagnostic_entry if key in DIAGNOSTIC_KINDS else _parse_entry
             findings.extend(parse_entry(raw, key=key, project=project, root=root) for raw in bucket)
+        if output.returncode not in SkylosAdapter.success_exit_codes and not findings:
+            msg = 'failed skylos output has no findings in recognized result buckets'
+            raise AdapterError(msg)
         return findings
 
 

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -174,7 +174,7 @@ class SkylosAdapter:
         Parameters
         ----------
         output : RawToolOutput
-            Captured skylos output with a success exit code.
+            Captured skylos output, possibly from a failed invocation.
         project : str
             Corpus project name to stamp onto findings.
         root : Path

--- a/liveness_primer/tools/vulture.py
+++ b/liveness_primer/tools/vulture.py
@@ -80,7 +80,7 @@ class VultureAdapter:
         Parameters
         ----------
         output : RawToolOutput
-            Captured vulture output with a success exit code.
+            Captured vulture output, possibly from a failed invocation.
         project : str
             Corpus project name to stamp onto findings.
         root : Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,13 +153,25 @@ def test_run_source_urls_is_opt_in(
 
 @pytest.mark.usefixtures('_isolated_cache')
 def test_run_failure_exit_code(tmp_path: Path, project_url: str, capsys: pytest.CaptureFixture[str]) -> None:
-    base_cmd = write_fake_detector_script(tmp_path / 'cli-base.json', [], exit_code=2, stderr='blew up')
-    head_cmd = write_fake_detector_script(tmp_path / 'cli-head.json', [])
+    base_cmd = write_fake_detector_script(
+        tmp_path / 'cli-base.json',
+        [BASE],
+        output_format='skylos',
+        exit_code=2,
+        stderr='base analysis incomplete',
+    )
+    head_cmd = write_fake_detector_script(
+        tmp_path / 'cli-head.json',
+        [BASE, NEW],
+        output_format='skylos',
+        exit_code=2,
+        stderr='head analysis incomplete',
+    )
     code = main(
         [
             'run',
             '--tool',
-            'vulture',
+            'skylos',
             '--project',
             project_url,
             '--old-cmd',
@@ -170,6 +182,10 @@ def test_run_failure_exit_code(tmp_path: Path, project_url: str, capsys: pytest.
     )
     captured = capsys.readouterr()
     assert code == EXIT_FAILURE
+    assert '1 new, 0 dropped, 0 changed' in captured.out
+    assert 'fresh' in captured.out
+    assert 'error[base]: exit code 2: base analysis incomplete' in captured.out
+    assert 'error[head]: exit code 2: head analysis incomplete' in captured.out
     assert 'run failure' in captured.err
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -161,6 +161,22 @@ def test_unparseable_output_is_recorded_as_error(tmp_path: Path, corpus_project:
     assert 'unparseable vulture output' in error.detail
 
 
+def test_unparseable_failure_output_preserves_exit_error(tmp_path: Path, corpus_project: CorpusProject) -> None:
+    base_cmd = write_fake_detector_script(
+        tmp_path / 'base.json',
+        [],
+        exit_code=2,
+        stderr='config exploded',
+        raw_lines=['?? not a report line'],
+    )
+    head_cmd = write_fake_detector_script(tmp_path / 'head.json', [])
+    report = runner_for(tmp_path).run_escape_hatch([corpus_project], base_cmd=base_cmd, head_cmd=head_cmd)
+    (error,) = report.projects[0].errors
+    assert error.exit_code == 2
+    assert 'config exploded' in error.detail
+    assert 'output parse failed' in error.detail
+
+
 def test_timeout_is_recorded_with_settings_override(tmp_path: Path) -> None:
     origin = create_fake_project(tmp_path / 'origin', init_git=True)
     assert origin.head_sha is not None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -151,7 +151,7 @@ def test_tool_failure_is_recorded_not_raised(tmp_path: Path, corpus_project: Cor
     assert report_has_failures(report)
 
 
-def test_failed_skylos_without_result_buckets_does_not_diff(
+def test_failed_skylos_with_empty_result_buckets_does_not_diff(
     tmp_path: Path,
     corpus_project: CorpusProject,
 ) -> None:
@@ -174,7 +174,7 @@ def test_failed_skylos_without_result_buckets_does_not_diff(
     )
     (project_report,) = report.projects
     (error,) = project_report.errors
-    assert 'no recognized result bucket' in error.detail
+    assert 'no findings in recognized result buckets' in error.detail
     assert project_report.base_findings == 1
     assert project_report.head_findings == 0
     assert project_report.diffs == ()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -47,9 +47,9 @@ def corpus_project(tmp_path: Path) -> CorpusProject:
     return CorpusProject(name='fakeproj', repo=origin.url, pin=origin.head_sha)
 
 
-def runner_for(tmp_path: Path, options: RunOptions = DEFAULT_OPTIONS) -> PrimerRunner:
+def runner_for(tmp_path: Path, options: RunOptions = DEFAULT_OPTIONS, *, tool: str = 'vulture') -> PrimerRunner:
     return PrimerRunner(
-        adapter=get_adapter('vulture'),
+        adapter=get_adapter(tool),
         store=CheckoutStore(tmp_path / 'cache'),
         isolation=UNENFORCED,
         options=options,
@@ -149,6 +149,37 @@ def test_tool_failure_is_recorded_not_raised(tmp_path: Path, corpus_project: Cor
     assert project_report.diffs == ()
     assert project_report.measured_cost_seconds is None
     assert report_has_failures(report)
+
+
+def test_failed_skylos_without_result_buckets_does_not_diff(
+    tmp_path: Path,
+    corpus_project: CorpusProject,
+) -> None:
+    base_cmd = write_fake_detector_script(
+        tmp_path / 'base.json',
+        [BASE_FINDING],
+        output_format='skylos',
+    )
+    head_cmd = write_fake_detector_script(
+        tmp_path / 'head.json',
+        [],
+        output_format='skylos',
+        exit_code=2,
+        stderr='analysis aborted',
+    )
+    report = runner_for(tmp_path, tool='skylos').run_escape_hatch(
+        [corpus_project],
+        base_cmd=base_cmd,
+        head_cmd=head_cmd,
+    )
+    (project_report,) = report.projects
+    (error,) = project_report.errors
+    assert 'no recognized result bucket' in error.detail
+    assert project_report.base_findings == 1
+    assert project_report.head_findings == 0
+    assert project_report.diffs == ()
+    assert project_report.totals == DiffTotals()
+    assert project_report.measured_cost_seconds is None
 
 
 def test_unparseable_output_is_recorded_as_error(tmp_path: Path, corpus_project: CorpusProject) -> None:

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -21,6 +21,7 @@ from liveness_primer.launcher import LauncherError, SyncLauncher, run_async, run
 from liveness_primer.testing import FakeFinding, create_fake_project, write_fake_detector_script
 from liveness_primer.testing.fake_detector import main
 from liveness_primer.testing.fake_project import DEFAULT_FILES, FakeProjectError
+from liveness_primer.tools.skylos import BUCKET_RULE_IDS
 
 
 def test_fake_finding_report_line_matches_vulture_format() -> None:
@@ -271,7 +272,7 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
 def test_main_skylos_format_clean_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     command = write_fake_detector_script(tmp_path / 'script.json', [], output_format='skylos')
     assert main(command[3:]) == 0
-    assert json.loads(capsys.readouterr().out) == {}
+    assert json.loads(capsys.readouterr().out) == {key: [] for key in BUCKET_RULE_IDS}
 
 
 def test_main_emits_skylos_danger_diagnostics(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -222,9 +222,23 @@ def test_skylos_explicit_rule_id_takes_precedence_over_bucket_mapping() -> None:
     assert mapped.rule_id == 'SKY-U001'
 
 
-@pytest.mark.parametrize('document', [{}, {'error': 'analysis aborted before producing a report'}])
-def test_skylos_rejects_failed_output_without_result_buckets(document: dict[str, object]) -> None:
-    with pytest.raises(AdapterError, match='no recognized result bucket'):
+@pytest.mark.parametrize(
+    'document',
+    [
+        {},
+        {'error': 'analysis aborted before producing a report'},
+        {
+            'unused_functions': [],
+            'unused_imports': [],
+            'unused_classes': [],
+            'unused_variables': [],
+            'unused_parameters': [],
+            'analysis_errors': [{'rule_id': 'SKY-ANALYSIS-INCOMPLETE'}],
+        },
+    ],
+)
+def test_skylos_rejects_failed_output_without_findings(document: dict[str, object]) -> None:
+    with pytest.raises(AdapterError, match='no findings in recognized result buckets'):
         SkylosAdapter.parse(raw(json.dumps(document), returncode=2), project='demo', root=ROOT)
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -222,6 +222,18 @@ def test_skylos_explicit_rule_id_takes_precedence_over_bucket_mapping() -> None:
     assert mapped.rule_id == 'SKY-U001'
 
 
+@pytest.mark.parametrize('document', [{}, {'error': 'analysis aborted before producing a report'}])
+def test_skylos_rejects_failed_output_without_result_buckets(document: dict[str, object]) -> None:
+    with pytest.raises(AdapterError, match='no recognized result bucket'):
+        SkylosAdapter.parse(raw(json.dumps(document), returncode=2), project='demo', root=ROOT)
+
+
+def test_skylos_accepts_failed_output_with_a_result_bucket() -> None:
+    document = {'unused_functions': [{'name': 'a', 'type': 'function', 'file': 'a.py', 'line': 1}]}
+    (finding,) = SkylosAdapter.parse(raw(json.dumps(document), returncode=2), project='demo', root=ROOT)
+    assert finding.symbol == 'a'
+
+
 def test_vulture_findings_carry_no_invented_rule_id() -> None:
     # Reporting contract §3.1 and acceptance 4: a detector without a native
     # rule ID yields None, never an invented tool-specific code.
@@ -454,7 +466,7 @@ def test_skylos_clamps_line_zero_to_one() -> None:
 
 def test_skylos_rejects_invalid_json() -> None:
     with pytest.raises(AdapterError, match='not valid JSON'):
-        SkylosAdapter.parse(raw('Error during analysis: boom'), project='demo', root=ROOT)
+        SkylosAdapter.parse(raw('Error during analysis: boom', returncode=2), project='demo', root=ROOT)
 
 
 def test_skylos_rejects_non_object_document() -> None:


### PR DESCRIPTION
## Summary
- parse nonempty detector stdout even when the detector returns a failure status
- retain parsed findings and render their diffs while also recording `ToolError` and returning primer exit code 1
- accept failed Skylos output only when at least one finding parses from a selected, recognized result bucket
- reject malformed JSON, error-only objects, and real Skylos-shaped documents whose standard result buckets are all empty
- make the fake Skylos emitter include the five standard result buckets, matching real Skylos output

## Testing
- reproduced with Skylos 4.33.2: an invalid `SKYLOS_GO_BIN` exits 2 and emits all five standard dead-code buckets as empty arrays plus `analysis_errors`
- `prek run --all-files`
- `python -m pytest` (569 passed, 3 skipped)
- coverage.py line and branch coverage: 100%
- mypy, pyright, and pydoclint
