### PR TITLE
docs: add Read the Docs user guide

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,126 @@
+# Use liveness_primer in CI
+
+A detector pull request can run `liveness_primer` as an evidence-producing job
+or as a strict regression gate. The workflow below writes a compact human
+report to the GitHub step summary and uploads the Markdown and complete JSON
+reports for interactive or automated review.
+
+## Complete GitHub Actions workflow
+
+```yaml
+name: Liveness Primer
+
+on:
+  pull_request:
+
+concurrency:
+  group: liveness-primer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  LIVENESS_PRIMER_REF: main
+  PYTHON_VERSION: "3.13"
+
+permissions:
+  contents: read
+
+jobs:
+  skylos:
+    name: Skylos blast radius
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out liveness_primer
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          repository: mcdigman/liveness_primer
+          ref: ${{ env.LIVENESS_PRIMER_REF }}
+          path: _liveness_primer
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache-dependency-glob: _liveness_primer/pyproject.toml
+
+      - name: Compare Skylos revisions across the corpus
+        run: |
+          set -o pipefail
+          uvx --from ./_liveness_primer \
+            liveness-primer run \
+            --tool skylos \
+            --repo "${{ github.server_url }}/${{ github.repository }}" \
+            --old "${{ github.event.pull_request.base.sha }}" \
+            --new "${{ github.event.pull_request.head.sha }}" \
+            --all \
+            --output github \
+            --json-out liveness-primer-report.json \
+            --jobs 2 \
+            --timeout 300 \
+            | tee liveness-primer-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload liveness_primer report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: liveness-primer-report
+          path: |
+            liveness-primer-report.md
+            liveness-primer-report.json
+          if-no-files-found: error
+```
+
+The workflow intentionally keeps the default token read-only, disables
+credential persistence, pins actions to full commit SHAs, and runs the two
+detector revisions against the packaged corpus. Adapt the adapter, job name,
+runtime budget, and concurrency to the detector repository.
+
+## Choose a gating policy
+
+Detector crashes, timeouts, and unparseable output fail the run without an
+extra gate. Add one or more `--fail-on` options to reject finding changes:
+
+- `--fail-on new`, `dropped`, or `changed` rejects that diff class;
+- `--fail-on any` requires the normalized finding set to remain unchanged; and
+- `--fail-on corpus-integrity` rejects corpus-integrity warnings.
+
+For a new feature, leaving finding-diff gates off makes CI an evidence-producing
+review job. For a semantics-preserving refactor, `--fail-on any` turns the same
+workflow into a strict regression gate.
+
+## Publish a pull-request digest
+
+Instead of or in addition to the step summary, a workflow can post a compact
+digest as a pull-request comment and link reviewers to the complete report and
+JSON artifact:
+
+![Example GitHub Actions comment summarizing a liveness_primer comparison](https://raw.githubusercontent.com/mcdigman/liveness_primer/main/design/liveness_primer_ci_application.png)
+
+Posting a comment requires a separate step with the minimum suitable pull
+request permission. Keep the comparison job itself read-only, and avoid
+granting write permissions to jobs that run untrusted pull-request code.
+
+## Add LLM-assisted triage
+
+The complete JSON report is suitable as input to an LLM-assisted review step.
+A downstream job can group changes by project or rule, highlight large or
+surprising clusters, call out detector failures, suggest which changes need
+human attention, and post an advisory digest as a pull-request comment.
+
+Keep the versioned JSON artifact as the source of truth and link every digest
+back to it. Finding messages and source excerpts originate in detector output
+and analyzed repositories, so treat them as untrusted content: run the model
+step without release credentials or unnecessary write permissions, and do not
+let generated prose replace deterministic gates or human review.
+
+<details>
+<summary>Example simulated LLM-assisted triage digest</summary>
+<br>
+<img
+  src="https://raw.githubusercontent.com/mcdigman/liveness_primer/main/design/llm_review_example.png"
+  alt="Simulated LLM pull-request review clustering new findings, identifying likely false positives, and recommending follow-up validation"
+  width="900"
+>
+</details>

--- a/docs/explorer.md
+++ b/docs/explorer.md
@@ -1,0 +1,59 @@
+# Explore reports in the browser
+
+The [static report explorer](https://mcdigman.github.io/liveness_primer/) turns
+a complete JSON report into an interactive review workspace. The report is
+processed locally in the browser rather than uploaded to an application
+server.
+
+## Create a report
+
+Write the JSON report alongside the terminal output:
+
+```bash
+liveness-primer run --tool vulture \
+  --repo https://github.com/jendrikseipp/vulture \
+  --old v2.15 \
+  --new v2.16 \
+  --all \
+  --output text \
+  --json-out liveness-primer-report.json
+```
+
+Open the [hosted explorer](https://mcdigman.github.io/liveness_primer/) and
+choose `liveness-primer-report.json`.
+
+## Review the blast radius
+
+The explorer can:
+
+- search, filter, group, and sort findings;
+- compare base and head analyzer output with pinned source evidence;
+- select or hide findings while reviewing a large change;
+- preserve review state in a versioned JSON record; and
+- export a focused Markdown or JSON handoff.
+
+[![Static report explorer showing filters, finding diffs, source context, and export controls](https://raw.githubusercontent.com/mcdigman/liveness_primer/main/design/report_explorer_demo.png)](https://mcdigman.github.io/liveness_primer/)
+
+A useful review sequence is:
+
+1. Check the totals and detector errors before interpreting finding changes.
+2. Filter new, dropped, and changed findings independently.
+3. Group by project, rule, or finding kind to identify unexpected clusters.
+4. Inspect the pinned source context for individual findings.
+5. Select the findings that need follow-up and export a focused handoff.
+
+The complete report remains the source of truth. A focused export is a review
+artifact, not a replacement for the original JSON report.
+
+## Build the explorer locally
+
+```bash
+cd explorer
+npm ci
+npm run build
+npm run serve
+```
+
+Open <http://127.0.0.1:4173/liveness-primer/explorer/>. See the
+[explorer development guide](https://github.com/mcdigman/liveness_primer/blob/main/explorer/README.md)
+for development and verification commands.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,67 @@
 # liveness_primer
 
-Primer for dead code detectors.
+`liveness_primer` is a differential testing harness for Python dead-code
+detectors and static linters. It runs two revisions of a detector against the
+same pinned open-source projects and reports the **blast radius**: which
+findings appeared, disappeared, changed, or could not be produced at all.
 
-This documentation is a placeholder while the implementation described in
-`.contracts/initial_contract.md` is being written. API reference pages will be
-added here as modules land.
+[Open the static report explorer](https://mcdigman.github.io/liveness_primer/).
 
-## Installation
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+usage
+explorer
+ci
+```
+
+## Why use it?
+
+A detector's own test suite can prove that selected examples behave correctly.
+It is much harder to see how a change affects real projects outside that suite.
+`liveness_primer` makes that impact reviewable before a release or merge.
+
+Use it to:
+
+- validate that an internal refactor preserves the detector's findings;
+- assess whether a new analysis finds the intended cases without producing a
+  wave of unrelated false positives;
+- verify that a bug fix removes or adds the expected findings without creating
+  new false negatives elsewhere;
+- catch parser, packaging, dependency, timeout, and execution failures that
+  only appear on some projects;
+- compare releases and review changes to messages, confidence, or severity;
+- publish a human-readable PR summary and a complete machine-readable report
+  from CI; and
+- feed the JSON report into deterministic automation or LLM-assisted triage.
+
+Managed comparisons use byte-identical, commit-pinned target projects for both
+detector revisions. The primer resolves the requested detector refs, prepares
+separate fingerprint-keyed environments, runs the same configured targets, and
+normalizes detector-specific output into one deterministic report model.
+
+## Quick start
+
+Install `liveness_primer` with Python 3.12 or newer:
 
 ```bash
 pip install liveness_primer
 ```
+
+Compare two Vulture refs on the pinned `pluggy` corpus project:
+
+```bash
+liveness-primer run --tool vulture \
+  --repo https://github.com/jendrikseipp/vulture \
+  --old v2.15 \
+  --new v2.16 \
+  -k pluggy \
+  --output text
+```
+
+Continue with:
+
+- {doc}`usage` for project selection, output formats, gates, and exit codes;
+- {doc}`explorer` for interactive review and focused exports; and
+- {doc}`ci` for a complete GitHub Actions workflow and automated triage ideas.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,133 @@
+# Run comparisons
+
+The built-in adapters support [Vulture](https://github.com/jendrikseipp/vulture)
+and [Skylos](https://github.com/duriantaco/skylos). A managed run installs the
+two requested detector revisions into separate environments and evaluates both
+against the same target-project commits.
+
+## Installation
+
+`liveness_primer` requires Python 3.12 or newer.
+
+```bash
+pip install liveness_primer
+```
+
+License verification with `corpus license-check` requires the `[license]`
+extra:
+
+```bash
+pip install "liveness_primer[license]"
+```
+
+## Compare detector revisions
+
+Provide the detector adapter, repository, and two refs to compare:
+
+```bash
+liveness-primer run --tool vulture \
+  --repo https://github.com/jendrikseipp/vulture \
+  --old v2.15 \
+  --new v2.16 \
+  -k pluggy \
+  --output text
+```
+
+The refs may be tags, branches, or commits accepted by Git. For reproducible
+review, prefer immutable commits or release tags.
+
+## Select target projects
+
+Project selection is explicit:
+
+- `-k NAME` selects matching projects from the packaged, commit-pinned corpus;
+- `--all` selects every corpus project supported by the adapter;
+- `--max-cost SECONDS` selects a useful subset within an estimated runtime
+  budget; and
+- `--project URL` uses one ad-hoc target repository instead of the packaged
+  corpus.
+
+## Interpret the result
+
+| Result | Meaning | What to investigate |
+| --- | --- | --- |
+| `+` new | Present only at the head revision | Intended new coverage or a new false positive |
+| `-` dropped | Present only at the base revision | Intended removal or a new false negative |
+| `~` changed | A matched finding has different recorded details | Message, confidence, or severity drift |
+| error | A detector invocation did not produce a valid result | Crash, timeout, or unparseable output |
+
+Path, symbol, kind, rule ID, and line span are part of finding identity. If one
+of those fields changes, the report contains one dropped and one new finding
+rather than a changed finding.
+
+Reports also record the exact detector revisions, corpus pins, environment and
+dependency differences, requested refs or commands, timing, and isolation
+status needed to interpret or reproduce the comparison.
+
+## Save and render reports
+
+`--output` controls the display written to standard output:
+
+- `--output text` produces terminal-oriented output;
+- `--output github` produces GitHub-flavored Markdown; and
+- `--output json` produces the complete report as JSON.
+
+Use `--json-out PATH` to archive the complete JSON report alongside text or
+GitHub output:
+
+```bash
+liveness-primer run --tool vulture \
+  --repo https://github.com/jendrikseipp/vulture \
+  --old v2.15 \
+  --new v2.16 \
+  --all \
+  --output text \
+  --json-out liveness-primer-report.json
+```
+
+Open that JSON file in the {doc}`explorer`, attach it to CI, or pass it to
+downstream automation.
+
+## Add regression gates
+
+Detector crashes, timeouts, and unparseable output fail the run without an
+extra gate. Repeat `--fail-on` to add project-specific regression policy:
+
+- `--fail-on new`, `dropped`, or `changed` rejects that diff class;
+- `--fail-on any` requires the normalized finding set to remain unchanged; and
+- `--fail-on corpus-integrity` rejects corpus-integrity warnings.
+
+For a new feature, leaving finding-diff gates off makes the run an
+evidence-producing review job. For a semantics-preserving refactor,
+`--fail-on any` turns it into a strict regression gate.
+
+## Use pre-built detector commands
+
+The escape hatch compares commands you have already built:
+
+```bash
+liveness-primer run --tool vulture \
+  --project https://github.com/pytest-dev/pluggy \
+  --old-cmd 'vulture-old' \
+  --new-cmd 'vulture-new'
+```
+
+Because the primer did not construct and verify these detector environments,
+the report marks the run as non-comparable and records that isolation was not
+enforced. `--fail-on` refuses to gate an escape-hatch run; use this mode for
+trusted local investigation, not as a managed CI substitute.
+
+## Exit codes
+
+- `0`: comparison completed and no enabled gate fired;
+- `1`: run or configuration failure, including detector invocation failures;
+- `2`: command-line usage error; and
+- `3`: an enabled `--fail-on` gate fired.
+
+## Maintain the corpus and schemas
+
+```bash
+liveness-primer corpus validate
+liveness-primer corpus license-check
+liveness-primer schema export
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,14 +38,19 @@ review, prefer immutable commits or release tags.
 
 ## Select target projects
 
-Project selection is explicit:
+Every run requires exactly one target-selection mode:
 
-- `-k NAME` selects matching projects from the packaged, commit-pinned corpus;
+- one or more `-k NAME` options select matching projects from the packaged,
+  commit-pinned corpus;
 - `--all` selects every corpus project supported by the adapter;
 - `--max-cost SECONDS` selects a useful subset within an estimated runtime
   budget; and
 - `--project URL` uses one ad-hoc target repository instead of the packaged
   corpus.
+
+Repeated `-k` options are combined into one selection. Do not combine that
+mode with `--all` or `--max-cost`, and do not combine `--project` with any
+corpus selector.
 
 ## Interpret the result
 
@@ -54,7 +59,12 @@ Project selection is explicit:
 | `+` new | Present only at the head revision | Intended new coverage or a new false positive |
 | `-` dropped | Present only at the base revision | Intended removal or a new false negative |
 | `~` changed | A matched finding has different recorded details | Message, confidence, or severity drift |
-| error | A detector invocation did not produce a valid result | Crash, timeout, or unparseable output |
+| error | A detector invocation failed | Failure details; usable partial findings may still be displayed |
+
+An error does not always mean that findings are absent. If a failed invocation
+emits parseable structured output, the report retains those findings and can
+still generate diffs while also recording the invocation error. Review both;
+the run still exits with a failure status.
 
 Path, symbol, kind, rule ID, and line span are part of finding identity. If one
 of those fields changes, the report contains one dropped and one new finding


### PR DESCRIPTION
## Summary

- replace the placeholder Read the Docs landing page with a product overview and quick start
- add task-oriented guides for CLI comparisons, the static report explorer, and CI/LLM-assisted review
- keep the CI example synchronized with the merged README and add Sphinx navigation across the guide

## Verification

- `prek run --all-files`
- `/Users/mcdigman/conda/envs/live-dev/bin/python -m sphinx -W --keep-going -b html docs <temporary-output>`
- verified rendered sidebar navigation, external screenshots, and collapsed LLM example

The diff is limited to four Markdown files under `docs/`.