### PR TITLE
fix(runner): harden native tool admission

### DIFF
--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -53,8 +53,8 @@ _STDERR_SNIPPET = 500
 
 _DIGEST_CHUNK = 1_048_576
 
-# Native analyzer engines can be much larger than report artifacts; 256 MiB
-# admits ordinary binaries while keeping operator-selected hashing bounded.
+# Hashing is already chunked, so this cap bounds admission I/O and time rather
+# than peak memory. 256 MiB leaves room for ordinary native analyzer engines.
 _MAX_NATIVE_TOOL_BYTES = 268_435_456
 
 
@@ -63,7 +63,7 @@ class RunnerError(LivenessPrimerError):
 
 
 def _executable_digest(path: Path) -> str:
-    """Hash one bounded executable while guarding against path replacement.
+    """Hash one bounded executable after verifying its opened-file identity.
 
     Parameters
     ----------
@@ -78,11 +78,11 @@ def _executable_digest(path: Path) -> str:
     Raises
     ------
     OSError
-        If the path changes during admission, is not a regular file, or
-        exceeds the native-tool size limit.
+        If the resolved path is not a regular file, the opened file differs
+        from the one inspected, or the read exceeds the native-tool size
+        limit.
     """
-    resolved = path.resolve(strict=True)
-    path_stat = resolved.lstat()
+    path_stat = path.lstat()
     if not stat.S_ISREG(path_stat.st_mode):
         msg = 'native tool is not a regular non-symlink file'
         raise OSError(msg)
@@ -90,7 +90,7 @@ def _executable_digest(path: Path) -> str:
         msg = f'native tool exceeds {_MAX_NATIVE_TOOL_BYTES} bytes'
         raise OSError(msg)
 
-    with resolved.open('rb') as stream:
+    with path.open('rb') as stream:
         opened_stat = os.fstat(stream.fileno())
         if not stat.S_ISREG(opened_stat.st_mode) or (
             opened_stat.st_dev,
@@ -185,7 +185,7 @@ def resolve_native_tools(adapter: DetectorAdapter, environ: Mapping[str, str]) -
                 raise RunnerError(msg)
             digest = _executable_digest(resolved)
         except (OSError, RuntimeError) as error:
-            msg = f'{variable} does not name a usable executable: {value}'
+            msg = f'{variable} does not name a usable executable: {value} ({error})'
             raise RunnerError(msg) from error
         admitted.append(AdmittedNativeTool(variable=variable, path=str(resolved), sha256=digest))
     return tuple(admitted)

--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -14,6 +14,7 @@ import inspect
 import os
 import platform
 import shutil
+import stat
 import sysconfig
 import tempfile
 from collections.abc import Mapping, Sequence
@@ -52,13 +53,17 @@ _STDERR_SNIPPET = 500
 
 _DIGEST_CHUNK = 1_048_576
 
+# Native analyzer engines can be much larger than report artifacts; 256 MiB
+# admits ordinary binaries while keeping operator-selected hashing bounded.
+_MAX_NATIVE_TOOL_BYTES = 268_435_456
+
 
 class RunnerError(LivenessPrimerError):
     """Raised when a run is misconfigured."""
 
 
 def _executable_digest(path: Path) -> str:
-    """Hash one executable's bytes for the manifest record.
+    """Hash one bounded executable while guarding against path replacement.
 
     Parameters
     ----------
@@ -69,12 +74,40 @@ def _executable_digest(path: Path) -> str:
     -------
     str
         SHA-256 hex digest.
+
+    Raises
+    ------
+    OSError
+        If the path changes during admission, is not a regular file, or
+        exceeds the native-tool size limit.
     """
-    digest = hashlib.sha256()
-    with path.open('rb') as stream:
+    resolved = path.resolve(strict=True)
+    path_stat = resolved.lstat()
+    if not stat.S_ISREG(path_stat.st_mode):
+        msg = 'native tool is not a regular non-symlink file'
+        raise OSError(msg)
+    if path_stat.st_size > _MAX_NATIVE_TOOL_BYTES:
+        msg = f'native tool exceeds {_MAX_NATIVE_TOOL_BYTES} bytes'
+        raise OSError(msg)
+
+    with resolved.open('rb') as stream:
+        opened_stat = os.fstat(stream.fileno())
+        if not stat.S_ISREG(opened_stat.st_mode) or (
+            opened_stat.st_dev,
+            opened_stat.st_ino,
+        ) != (path_stat.st_dev, path_stat.st_ino):
+            msg = 'native tool changed while it was being admitted'
+            raise OSError(msg)
+
+        digest = hashlib.sha256()
+        bytes_read = 0
         for chunk in iter(lambda: stream.read(_DIGEST_CHUNK), b''):
+            bytes_read += len(chunk)
+            if bytes_read > _MAX_NATIVE_TOOL_BYTES:
+                msg = f'native tool exceeds {_MAX_NATIVE_TOOL_BYTES} bytes'
+                raise OSError(msg)
             digest.update(chunk)
-    return digest.hexdigest()
+        return digest.hexdigest()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 import liveness_primer.cli
+import liveness_primer.runner as runner_module
 from liveness_primer.cli import EXIT_FAILURE, EXIT_GATE, EXIT_OK, main
 from liveness_primer.config import Corpus, CorpusProject, ToolSettings
 from liveness_primer.filesystem import atomic_write_text, read_small_text
@@ -364,6 +365,37 @@ def test_run_unknown_tool_fails_cleanly(capsys: pytest.CaptureFixture[str]) -> N
     code = main(['run', '--tool', 'pylint', '--repo', 'r', '--old', 'a', '--new', 'b'])
     assert code == EXIT_FAILURE
     assert 'unknown tool' in capsys.readouterr().err
+
+
+@pytest.mark.usefixtures('_isolated_cache')
+def test_run_reports_native_tool_admission_cause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    engine = tmp_path / 'skylos-go'
+    atomic_write_text(engine, '#!/bin/sh\nexit 0\n')
+    engine.chmod(0o755)
+    limit = engine.stat().st_size - 1
+    monkeypatch.setattr(runner_module, '_MAX_NATIVE_TOOL_BYTES', limit)
+    monkeypatch.setenv('SKYLOS_GO_BIN', str(engine))
+
+    code = main(
+        [
+            'run',
+            '--tool',
+            'skylos',
+            '--project',
+            'https://example.invalid/project',
+            '--old-cmd',
+            'true',
+            '--new-cmd',
+            'true',
+        ]
+    )
+
+    assert code == EXIT_FAILURE
+    assert f'native tool exceeds {limit} bytes' in capsys.readouterr().err
 
 
 def test_usage_errors_exit_two() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,9 @@
 
 import asyncio
 import hashlib
+import os
 import re
+import stat
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -13,6 +15,7 @@ from typing import cast
 
 import pytest
 
+import liveness_primer.runner as runner_module
 from liveness_primer.config import CorpusProject, ToolSettings
 from liveness_primer.corpus import CheckoutStore
 from liveness_primer.envcache import DetectorEnvironments
@@ -872,7 +875,7 @@ def test_fake_skylos_analyses_selection_reaches_argv_and_report(tmp_path: Path) 
 
 
 def write_fake_native_engine(path: Path) -> Path:
-    path.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    atomic_write_text(path, '#!/bin/sh\nexit 0\n')
     path.chmod(0o755)
     return path
 
@@ -912,14 +915,76 @@ def test_native_tool_record_withholds_the_host_path(tmp_path: Path) -> None:
     assert admitted.path not in str(payload)
 
 
-@pytest.mark.parametrize('name', ['absent-engine', 'plain-file', 'a-directory'])
-def test_resolve_native_tools_rejects_unusable_paths(tmp_path: Path, name: str) -> None:
+def test_resolve_native_tools_rejects_an_unresolved_final_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = write_fake_native_engine(tmp_path / 'skylos-go')
+    link = tmp_path / 'link-to-engine'
+    link.symlink_to(engine)
+    real_resolve = Path.resolve
+
+    def leave_final_link(path: Path, *, strict: bool = False) -> Path:
+        if path == link:
+            return path.absolute()
+        return real_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, 'resolve', leave_final_link)
+    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+        resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(link)})
+
+
+def test_resolve_native_tools_rejects_an_oversized_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = write_fake_native_engine(tmp_path / 'skylos-go')
+    monkeypatch.setattr(runner_module, '_MAX_NATIVE_TOOL_BYTES', engine.stat().st_size - 1)
+    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+        resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
+
+
+def test_executable_digest_rejects_a_changed_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = write_fake_native_engine(tmp_path / 'skylos-go')
+    real_fstat = os.fstat
+
+    def changed_fstat(descriptor: int) -> os.stat_result:
+        values = list(real_fstat(descriptor))
+        values[stat.ST_INO] += 1
+        return os.stat_result(values)
+
+    monkeypatch.setattr(os, 'fstat', changed_fstat)
+    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+        resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
+
+
+def test_executable_digest_stops_if_the_file_grows_while_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = write_fake_native_engine(tmp_path / 'skylos-go')
+    actual_stat = engine.stat()
+    bounded_values = list(actual_stat)
+    bounded_values[stat.ST_SIZE] = actual_stat.st_size - 1
+    bounded_stat = os.stat_result(bounded_values)
+    monkeypatch.setattr(Path, 'lstat', lambda _path: bounded_stat)
+    monkeypatch.setattr(os, 'fstat', lambda _descriptor: bounded_stat)
+    monkeypatch.setattr(runner_module, '_MAX_NATIVE_TOOL_BYTES', actual_stat.st_size - 1)
+    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+        resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
+
+
+@pytest.mark.parametrize('kind', ['absent', 'plain-file', 'directory'])
+def test_resolve_native_tools_rejects_unusable_paths(tmp_path: Path, kind: str) -> None:
     # A wrong path must stop the run here: silently falling through would
     # leave both sides analyzing Go sources incompletely.
-    target = tmp_path / name
-    if name == 'plain-file':
-        target.write_text('not executable\n', encoding='utf-8')
-    elif name == 'a-directory':
+    target = tmp_path / 'unusable-native-tool'
+    if kind == 'plain-file':
+        atomic_write_text(target, 'not executable\n')
+    elif kind == 'directory':
         target.mkdir()
     with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name'):
         resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(target)})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -915,23 +915,27 @@ def test_native_tool_record_withholds_the_host_path(tmp_path: Path) -> None:
     assert admitted.path not in str(payload)
 
 
-def test_resolve_native_tools_rejects_an_unresolved_final_symlink(
+def test_resolve_native_tools_rejects_a_symlink_swap_after_resolution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = write_fake_native_engine(tmp_path / 'skylos-go')
-    link = tmp_path / 'link-to-engine'
-    link.symlink_to(engine)
-    real_resolve = Path.resolve
+    saved_engine = tmp_path / 'original-skylos-go'
+    replacement = write_fake_native_engine(tmp_path / 'replacement-skylos-go')
+    real_is_file = Path.is_file
 
-    def leave_final_link(path: Path, *, strict: bool = False) -> Path:
-        if path == link:
-            return path.absolute()
-        return real_resolve(path, strict=strict)
+    def swap_after_check(self: Path) -> bool:
+        is_file = real_is_file(self)
+        if self == engine:
+            self.replace(saved_engine)
+            self.symlink_to(replacement)
+        return is_file
 
-    monkeypatch.setattr(Path, 'resolve', leave_final_link)
-    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
-        resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(link)})
+    # The hook deterministically schedules a real symlink replacement in the
+    # otherwise nondeterministic resolve-to-admission race window.
+    monkeypatch.setattr(Path, 'is_file', swap_after_check)
+    with pytest.raises(RunnerError, match='native tool is not a regular non-symlink file'):
+        resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
 
 
 def test_resolve_native_tools_rejects_an_oversized_executable(
@@ -939,8 +943,11 @@ def test_resolve_native_tools_rejects_an_oversized_executable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = write_fake_native_engine(tmp_path / 'skylos-go')
-    monkeypatch.setattr(runner_module, '_MAX_NATIVE_TOOL_BYTES', engine.stat().st_size - 1)
-    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+    limit = engine.stat().st_size - 1
+    # Lowering the production cap avoids constructing a 256 MiB test artifact;
+    # the same size comparison and operator-facing error path are exercised.
+    monkeypatch.setattr(runner_module, '_MAX_NATIVE_TOOL_BYTES', limit)
+    with pytest.raises(RunnerError, match=rf'native tool exceeds {limit} bytes'):
         resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
 
 
@@ -956,8 +963,11 @@ def test_executable_digest_rejects_a_changed_file(
         values[stat.ST_INO] += 1
         return os.stat_result(values)
 
+    # A real lstat-to-open replacement race is nondeterministic. Altering only
+    # the opened inode pins the identity-mismatch branch; it is not end-to-end
+    # evidence that the later subprocess executes the recorded digest.
     monkeypatch.setattr(os, 'fstat', changed_fstat)
-    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+    with pytest.raises(RunnerError, match='native tool changed while it was being admitted'):
         resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
 
 
@@ -970,10 +980,13 @@ def test_executable_digest_stops_if_the_file_grows_while_reading(
     bounded_values = list(actual_stat)
     bounded_values[stat.ST_SIZE] = actual_stat.st_size - 1
     bounded_stat = os.stat_result(bounded_values)
+    # A concurrent grow during this short read would be flaky to schedule.
+    # Fixed stat results keep the admission checks below the lowered cap while
+    # the real stream crosses it, pinning only the post-open growth guard.
     monkeypatch.setattr(Path, 'lstat', lambda _path: bounded_stat)
     monkeypatch.setattr(os, 'fstat', lambda _descriptor: bounded_stat)
     monkeypatch.setattr(runner_module, '_MAX_NATIVE_TOOL_BYTES', actual_stat.st_size - 1)
-    with pytest.raises(RunnerError, match='SKYLOS_GO_BIN does not name a usable executable'):
+    with pytest.raises(RunnerError, match='native tool exceeds'):
         resolve_native_tools(get_adapter('skylos'), {'SKYLOS_GO_BIN': str(engine)})
 
 


### PR DESCRIPTION
## Summary

- bound native executable hashing to 256 MiB and reject unresolved final symlinks or non-regular files
- compare the opened descriptor device/inode with the admitted path before hashing and retain a runtime growth cap
- use atomic writes and fixed fixture paths in the native-tool tests, with regression coverage for symlink, replacement, and growth cases

## Validation

- Skylos 4.33.2 danger scan reports only the known SKY-D212 and SKY-D253 findings
- 573 passed, 3 skipped
- 100% line and branch coverage
- prek run --all-files
- mypy and pyright
- pydoclint