### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Report and manifest payloads carry their own `schema_version`, versioned
 independently of the package version; `liveness-primer --version` prints both.
 
-## [Unreleased]
+## [0.1.0] - 2026-08-14
 
 This is the first release version of `liveness_primer`, so everything is new.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,9 +5,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
 title: "liveness_primer"
-version: 0.0.1
-# date-released is omitted until the first release is cut; add it (and bump
-# version above) in the release commit.
+version: 0.1.0
+date-released: 2026-08-14
 abstract: "Differential testing harness for Python dead-code detectors and static linters: run a detector at two revisions across a corpus and diff the findings"
 authors:
   - family-names: "Digman"

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveness-primer-explorer",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveness-primer-explorer",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^19.2.8",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -37,5 +37,5 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "type": "module",
-  "version": "0.0.1"
+  "version": "0.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liveness_primer"
-version = "0.0.1"
+version = "0.1.0"
 description = "Differential testing harness for Python dead-code detectors and static linters: run a detector at two revisions across a corpus and diff the findings."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "liveness-primer"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
First release version. Follows the [Cutting a release](CONTRIBUTING.md#cutting-a-release) checklist, steps 1 and 2; step 3 (publishing the GitHub Release) is a separate maintainer action after this merges.

## Changed

| File | Change |
| --- | --- |
| `pyproject.toml` | `project.version` → `0.1.0` |
| `CITATION.cff` | `version:` → `0.1.0`, added `date-released: 2026-08-14` (replacing the placeholder comment) |
| `uv.lock` | root `liveness-primer` package version → `0.1.0` |
| `explorer/package.json` | `version` → `0.1.0` |
| `explorer/package-lock.json` | root and `packages[""]` versions → `0.1.0` |
| `CHANGELOG.md` | `## [Unreleased]` → `## [0.1.0] - 2026-08-14` |

## Deliberately unchanged

- **`SCHEMA_VERSION` (`liveness_primer/findings.py`, `2.2.0`)** — report/manifest payloads are versioned independently of the package, and no payload changed here. The `0.0.1` in `explorer/tests/browser/explorer.spec.js` is an intentionally-unsupported schema version fixture, not a package version.
- **`Development Status :: 3 - Alpha` classifier** — left as-is; changing the maturity claim is a separate call from the version bump.

## Verification

- `CITATION.cff` parses as YAML with `date-released` as a real date; `pyproject.toml`, `package.json`, and `package-lock.json` parse and all report `0.1.0`.
- No CI job runs `uv lock --check`/`--frozen`, and the only lockfile delta is the editable root package's own version, so the hand edit is equivalent to a re-lock.
- No test asserts the real package version (`tests/test_cli.py` monkeypatches `metadata_version`); `liveness-primer --version` reads it from installed metadata.
- Pre-commit hooks passed (JSON/TOML/YAML checks included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)