### PR TITLE
feat(corpus): add issue-backed detector targets

### DIFF
--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -18,9 +18,14 @@ projects:
           - src
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - src
-        cost: 2.0
+        cost: 4.0
 
   - name: click
     repo: https://github.com/pallets/click
@@ -32,9 +37,14 @@ projects:
           - src/click
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - src/click
-        cost: 3.0
+        cost: 6.0
 
   - name: jinja
     repo: https://github.com/pallets/jinja
@@ -46,9 +56,14 @@ projects:
           - src/jinja2
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - src/jinja2
-        cost: 4.0
+        cost: 8.0
 
   - name: rich
     repo: https://github.com/Textualize/rich
@@ -74,9 +89,14 @@ projects:
           - src/pluggy
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - src/pluggy
-        cost: 2.0
+        cost: 3.0
 
   - name: more-itertools
     repo: https://github.com/more-itertools/more-itertools
@@ -88,9 +108,14 @@ projects:
           - more_itertools
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - more_itertools
-        cost: 2.0
+        cost: 5.0
 
   - name: platformdirs
     repo: https://github.com/tox-dev/platformdirs
@@ -102,9 +127,14 @@ projects:
           - src/platformdirs
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - src/platformdirs
-        cost: 2.0
+        cost: 3.0
 
   - name: httpx
     repo: https://github.com/encode/httpx
@@ -188,9 +218,14 @@ projects:
           - src/requests
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - src/requests
-        cost: 2.0
+        cost: 6.0
 
   # Parent of mitmproxy/mitmproxy#8136, preserving accepted dead-code removals.
   - name: mitmproxy-pre-cleanup
@@ -218,9 +253,14 @@ projects:
           - starlette
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         targets:
           - starlette
-        cost: 4.0
+        cost: 7.0
 
   # javascript coverage
   - name: remark

--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -222,6 +222,46 @@ projects:
           - starlette
         cost: 10.0
 
+  # ---------------------------------------------------------------------
+  # Proposed entries under evaluation (GitHub issues #25, #27-#33).
+  # Costs and targets are transcribed from each issue's benchmark section;
+  # non-Python projects set include_tools because vulture is Python-only.
+  # ---------------------------------------------------------------------
+
+  # Issue #25. JavaScript monorepo: ESM exports, parser/plugin, AST, and
+  # JSDoc/type-declaration patterns. The proposal quotes "~12 seconds under
+  # skylos" without stating sides or targets, so both need benchmarking
+  # before this entry leaves the testing branch.
+  - name: remark
+    repo: https://github.com/remarkjs/remark
+    license: MIT
+    pin: 360840f0c0e4c8a274e525cc5d7fb4939d922b73
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        targets:
+          - packages
+        cost: 12.0
+
+  # Issue #27. First Go entry: exercises skylos's native Go engine, module
+  # and package handling, interfaces, embedded types, and callback-heavy
+  # command/update/view patterns. Targets the repository root.
+  - name: bubbletea
+    repo: https://github.com/charmbracelet/bubbletea
+    license: MIT
+    pin: faf4dcf54a92bab2fe3bf6f4715adf44f2fc245d
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        cost: 20.0
+
   # numerical and scientific python
   - name: xarray
     repo: https://github.com/pydata/xarray
@@ -286,6 +326,22 @@ projects:
           - copyparty
           - bin/hooks
         cost: 2.0
+
+  # Issue #33. First Rust and TypeScript coverage: a multi-crate workspace
+  # with a PyO3 boundary plus a TypeScript SDK. The narrow targets skip the
+  # Python package, whose bundled _dist JavaScript dominated a root scan.
+  - name: headroom-rust
+    repo: https://github.com/headroomlabs-ai/headroom
+    license: Apache-2.0
+    pin: b77d61291399976985f12adcd6014aba2f0275cf
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        targets:
+          - crates
+          - sdk
+        cost: 80.0
 
   # pydantic consumer, real secrets and danger
   - name: elementary

--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -16,11 +16,11 @@ projects:
       vulture:
         targets:
           - src
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - src
-        cost: 6.0
+        cost: 2.0
 
   - name: click
     repo: https://github.com/pallets/click
@@ -30,11 +30,11 @@ projects:
       vulture:
         targets:
           - src/click
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - src/click
-        cost: 11.0
+        cost: 3.0
 
   - name: jinja
     repo: https://github.com/pallets/jinja
@@ -44,11 +44,11 @@ projects:
       vulture:
         targets:
           - src/jinja2
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - src/jinja2
-        cost: 19.0
+        cost: 4.0
 
   - name: rich
     repo: https://github.com/Textualize/rich
@@ -58,11 +58,11 @@ projects:
       vulture:
         targets:
           - rich
-        cost: 5.0
+        cost: 1.0
       skylos:
         targets:
           - rich
-        cost: 38.0
+        cost: 5.0
 
   - name: pluggy
     repo: https://github.com/pytest-dev/pluggy
@@ -90,7 +90,7 @@ projects:
       skylos:
         targets:
           - more_itertools
-        cost: 3.5
+        cost: 2.0
 
   - name: platformdirs
     repo: https://github.com/tox-dev/platformdirs
@@ -104,7 +104,7 @@ projects:
       skylos:
         targets:
           - src/platformdirs
-        cost: 2.5
+        cost: 2.0
 
   - name: httpx
     repo: https://github.com/encode/httpx
@@ -114,11 +114,11 @@ projects:
       vulture:
         targets:
           - httpx
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - httpx
-        cost: 5.5
+        cost: 2.0
 
   # Shared with Skylos's pinned real-repository framework corpus.
   - name: pydantic
@@ -129,11 +129,11 @@ projects:
       vulture:
         targets:
           - pydantic
-        cost: 7.0
+        cost: 1.0
       skylos:
         targets:
           - pydantic
-        cost: 90.0
+        cost: 11.0
 
   - name: flask
     repo: https://github.com/pallets/flask
@@ -143,11 +143,11 @@ projects:
       vulture:
         targets:
           - src/flask
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - src/flask
-        cost: 13.0
+        cost: 3.0
 
   - name: pytest
     repo: https://github.com/pytest-dev/pytest
@@ -157,11 +157,11 @@ projects:
       vulture:
         targets:
           - src/_pytest
-        cost: 6.0
+        cost: 1.0
       skylos:
         targets:
           - src/_pytest
-        cost: 100.0
+        cost: 12.0
 
   # Parent of psf/black#5041, preserving four maintainer-accepted dead symbols.
   - name: black-pre-cleanup
@@ -172,11 +172,11 @@ projects:
       vulture:
         targets:
           - src/black
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - src/black
-        cost: 8.0
+        cost: 3.0
 
   - name: requests
     repo: https://github.com/psf/requests
@@ -186,11 +186,11 @@ projects:
       vulture:
         targets:
           - src/requests
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - src/requests
-        cost: 8.5
+        cost: 2.0
 
   # Parent of mitmproxy/mitmproxy#8136, preserving accepted dead-code removals.
   - name: mitmproxy-pre-cleanup
@@ -201,11 +201,11 @@ projects:
       vulture:
         targets:
           - mitmproxy
-        cost: 10.0
+        cost: 1.0
       skylos:
         targets:
           - mitmproxy
-        cost: 110.0
+        cost: 19.0
 
   # Shared with Skylos's pinned real-repository framework corpus.
   - name: starlette
@@ -216,11 +216,11 @@ projects:
       vulture:
         targets:
           - starlette
-        cost: 2.0
+        cost: 1.0
       skylos:
         targets:
           - starlette
-        cost: 10.0
+        cost: 4.0
 
   # javascript coverage
   - name: remark
@@ -229,11 +229,13 @@ projects:
     pin: 360840f0c0e4c8a274e525cc5d7fb4939d922b73
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         targets:
           - packages
-        cost: 12.0
+        cost: 2.0
 
   # go coverage
   - name: bubbletea
@@ -242,6 +244,8 @@ projects:
     pin: faf4dcf54a92bab2fe3bf6f4715adf44f2fc245d
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -249,7 +253,7 @@ projects:
           - secrets
           - quality
           - ai-defects
-        cost: 20.0
+        cost: 18.0
 
   # numerical and scientific python
   - name: xarray
@@ -258,14 +262,14 @@ projects:
     pin: c2998a75ef32f6cf4d62cd946f2200ca953550d9
     tools:
       vulture:
-        cost: 3.0
+        cost: 4.0
       skylos:
         analyses:
           - danger
           - secrets
           - quality
           - ai-defects
-        cost: 140.0
+        cost: 83.0
 
   # sql and mock data coverage
   - name: meltano-sdk
@@ -286,7 +290,8 @@ projects:
           - ai-defects
         targets:
           - singer_sdk
-        cost: 40.0
+          - tests
+        cost: 20.0
 
   # numerical python
   - name: fluids
@@ -297,7 +302,7 @@ projects:
       vulture:
         targets:
           - fluids
-        cost: 2.0
+        cost: 1.0
       skylos:
         analyses:
           - danger
@@ -306,7 +311,7 @@ projects:
           - ai-defects
         targets:
           - fluids
-        cost: 60.0
+        cost: 21.0
 
   # sql injection coverage
   - name: todo
@@ -316,7 +321,7 @@ projects:
     tools:
       vulture:
         targets:
-          - src/todo/domain/status.py
+          - src/todo
         cost: 1.0
       skylos:
         analyses:
@@ -326,7 +331,7 @@ projects:
           - ai-defects
         targets:
           - src/todo
-        cost: 10.0
+        cost: 6.0
 
   # javascript and python coverage
   - name: copyparty
@@ -343,7 +348,7 @@ projects:
         targets:
           - copyparty/web
           - bin/hooks
-        cost: 10.0
+        cost: 3.0
 
   # rust and typescript coverage
   - name: headroom-rust
@@ -352,6 +357,9 @@ projects:
     pin: b77d61291399976985f12adcd6014aba2f0275cf
     include_tools:
       - skylos
+    # The scoped crates/ and sdk/ trees contain no Python files.
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         targets:
@@ -362,7 +370,7 @@ projects:
           - secrets
           - quality
           - ai-defects
-        cost: 80.0
+        cost: 32.0
 
   # java servlet coverage
   - name: verademo
@@ -371,6 +379,8 @@ projects:
     pin: d2d1a34119a6eba955a24ab2b7935fe94c1c7286
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -380,7 +390,7 @@ projects:
           - ai-defects
         targets:
           - app/src/main/java
-        cost: 5.0
+        cost: 2.0
 
   # dart coverage
   - name: shelf
@@ -389,6 +399,8 @@ projects:
     pin: fb3f931d2c158d794e83c1b76b7be4b625db3c28
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -397,7 +409,7 @@ projects:
           - ai-defects
         targets:
           - pkgs/_shelf_compliance
-        cost: 4.0
+        cost: 2.0
 
   # shell coverage
   - name: sdkman-cli
@@ -406,6 +418,8 @@ projects:
     pin: f02e5de113ea46a95e5e2fd795eabe6f2b7d4095
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -424,6 +438,8 @@ projects:
     pin: 7b0678f7d2e3b44898d4c602b082835567332782
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -433,7 +449,7 @@ projects:
           - ai-defects
         targets:
           - Src/Generator.Cli
-        cost: 6.0
+        cost: 2.0
 
   # kotlin coverage
   - name: ktor-samples
@@ -442,6 +458,8 @@ projects:
     pin: 69dcff3fa81daa85f936cfb7f17007761363c303
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -451,7 +469,7 @@ projects:
         targets:
           - filelisting/src
           - httpbin/src
-        cost: 4.0
+        cost: 3.0
 
   # php coverage
   - name: slim
@@ -460,6 +478,8 @@ projects:
     pin: 80900fb39cafce3ae53b18a2c4f642a122f03095
     include_tools:
       - skylos
+    exclude_tools:
+      - vulture
     tools:
       skylos:
         analyses:
@@ -468,7 +488,7 @@ projects:
           - ai-defects
         targets:
           - Slim
-        cost: 4.0
+        cost: 3.0
 
   # pydantic consumer, real secrets and danger
   - name: elementary
@@ -480,6 +500,8 @@ projects:
     tools:
       vulture:
         cost: 1.0
+      skylos:
+        cost: 6.0
 
   # runtime-generated decorator wrappers
   - name: beartype
@@ -491,6 +513,8 @@ projects:
     tools:
       vulture:
         cost: 1.0
+      skylos:
+        cost: 14.0
 
   # Decorator and annotation-defined GraphQL schemas
   - name: strawberry
@@ -502,6 +526,8 @@ projects:
     tools:
       vulture:
         cost: 2.0
+      skylos:
+        cost: 16.0
 
   # settings-discovered components, signal handlers, middleware
   - name: scrapy
@@ -513,6 +539,8 @@ projects:
     tools:
       vulture:
         cost: 2.0
+      skylos:
+        cost: 17.0
 
   # Paired Python model code and Typescript implementation
   - name: bokeh
@@ -524,6 +552,8 @@ projects:
     tools:
       vulture:
         cost: 3.0
+      skylos:
+        cost: 55.0
 
   # Metadata-discovered cloud provider and service-check registries;
   # blocking vulture workflow enforces confidence 100.
@@ -545,7 +575,9 @@ projects:
         targets:
           - .
         expected_clean: true
-        cost: 14.0
+        cost: 11.0
+      skylos:
+        cost: 368.0
 
   # Dynamically selected visualization backends, observer-decorated
   # callbacks, maintained Vulture allowlist; mirrors [tool.vulture].
@@ -569,6 +601,8 @@ projects:
           - tools/vulture_allowlist.py
         expected_clean: true
         cost: 6.0
+      skylos:
+        cost: 62.0
 
   # Gateway plus plugin architecture with dynamically registered MCP tools
   - name: mcp-context-forge
@@ -588,7 +622,12 @@ projects:
           - mcpgateway
           - plugins
         expected_clean: true
-        cost: 16.0
+        cost: 4.0
+      skylos:
+        args:
+          - --exclude
+          - "mcp-servers/templates/python/{{cookiecutter.project_slug}}/tests/test_server.py"
+        cost: 264.0
 
   # OS-selected modules, extension-backed public APIs, registered exit
   # handlers; vulture target is maintained but non-blocking
@@ -608,6 +647,8 @@ projects:
         targets:
           - .
         cost: 1.0
+      skylos:
+        cost: 8.0
 
   # Scale target: ~1,500 tracked Python files.
   - name: pandas
@@ -621,6 +662,8 @@ projects:
         args:
           - --min-confidence=100
         cost: 13.0
+      skylos:
+        cost: 168.0
 
   # Widgets, layouts, and hooks wired through @expose_command and
   # hook.subscribe rather than direct calls. Has [tool.vulture]
@@ -637,7 +680,12 @@ projects:
           - --exclude=test/configs/syntaxerr.py
         targets:
           - libqtile
-        cost: 2.0
+        cost: 1.0
+      skylos:
+        args:
+          - --exclude
+          - test/configs/syntaxerr.py
+        cost: 19.0
 
   # Whitelist-module semantics.
   # Mirrored sync/async hierarchies and command-table dispatch.
@@ -654,7 +702,9 @@ projects:
         targets:
           - redis
           - whitelist.py
-        cost: 3.0
+        cost: 2.0
+      skylos:
+        cost: 36.0
 
   # Self-hosting: Vulture's own AST visitor, config, reporting, built-in
   # whitelists, and the tests encoding its supported Python constructs.
@@ -672,6 +722,8 @@ projects:
           - tests/
         expected_clean: true
         cost: 1.0
+      skylos:
+        cost: 2.0
 
   # Self-hosting liveness_primer itself: invocation builder,
   # detector parsers, diffing, runner backends, reporting, and their tests.
@@ -690,4 +742,4 @@ projects:
           - liveness_primer
           - tests
         expected_clean: true
-        cost: 12.0
+        cost: 4.0

--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -222,16 +222,7 @@ projects:
           - starlette
         cost: 10.0
 
-  # ---------------------------------------------------------------------
-  # Proposed entries under evaluation (GitHub issues #25, #27-#33).
-  # Costs and targets are transcribed from each issue's benchmark section;
-  # non-Python projects set include_tools because vulture is Python-only.
-  # ---------------------------------------------------------------------
-
-  # Issue #25. JavaScript monorepo: ESM exports, parser/plugin, AST, and
-  # JSDoc/type-declaration patterns. The proposal quotes "~12 seconds under
-  # skylos" without stating sides or targets, so both need benchmarking
-  # before this entry leaves the testing branch.
+  # javascript coverage
   - name: remark
     repo: https://github.com/remarkjs/remark
     license: MIT
@@ -244,9 +235,7 @@ projects:
           - packages
         cost: 12.0
 
-  # Issue #27. First Go entry: exercises skylos's native Go engine, module
-  # and package handling, interfaces, embedded types, and callback-heavy
-  # command/update/view patterns. Targets the repository root.
+  # go coverage
   - name: bubbletea
     repo: https://github.com/charmbracelet/bubbletea
     license: MIT
@@ -267,69 +256,96 @@ projects:
     repo: https://github.com/pydata/xarray
     license: Apache-2.0
     pin: c2998a75ef32f6cf4d62cd946f2200ca953550d9
-    include_tools:
-      - vulture
     tools:
       vulture:
         cost: 3.0
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        cost: 140.0
 
   # sql and mock data coverage
   - name: meltano-sdk
     repo: https://github.com/meltano/sdk
     license: Apache-2.0
     pin: ef3a36bb3da8ff30a5f9d935da99a747dc135cad
-    include_tools:
-      - vulture
     tools:
       vulture:
         targets:
           - singer_sdk/
           - tests/
         cost: 1.0
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        targets:
+          - singer_sdk
+        cost: 40.0
 
   # numerical python
   - name: fluids
     repo: https://github.com/CalebBell/fluids
     license: MIT
     pin: 5fa218f9c15f62e2a7f864b97991f4837ddeefe7
-    include_tools:
-      - vulture
     tools:
       vulture:
         targets:
           - fluids
         cost: 2.0
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        targets:
+          - fluids
+        cost: 60.0
 
   # sql injection coverage
   - name: todo
     repo: https://github.com/maltekliemann/todo
     license: MIT
     pin: f122c1722b673a482cb98f97680caccf99102d7a
-    include_tools:
-      - vulture
     tools:
       vulture:
         targets:
           - src/todo/domain/status.py
         cost: 1.0
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        targets:
+          - src/todo
+        cost: 10.0
 
   # javascript and python coverage
   - name: copyparty
     repo: https://github.com/9001/copyparty
     license: MIT
     pin: 6115eb452d2c2bbdeef5d19098fac17db69ddaa8
-    include_tools:
-      - vulture
     tools:
       vulture:
         targets:
           - copyparty
           - bin/hooks
         cost: 2.0
+      skylos:
+        targets:
+          - copyparty/web
+          - bin/hooks
+        cost: 10.0
 
-  # Issue #33. First Rust and TypeScript coverage: a multi-crate workspace
-  # with a PyO3 boundary plus a TypeScript SDK. The narrow targets skip the
-  # Python package, whose bundled _dist JavaScript dominated a root scan.
+  # rust and typescript coverage
   - name: headroom-rust
     repo: https://github.com/headroomlabs-ai/headroom
     license: Apache-2.0
@@ -341,7 +357,118 @@ projects:
         targets:
           - crates
           - sdk
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
         cost: 80.0
+
+  # java servlet coverage
+  - name: verademo
+    repo: https://github.com/veracode/verademo
+    license: MIT
+    pin: d2d1a34119a6eba955a24ab2b7935fe94c1c7286
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        targets:
+          - app/src/main/java
+        cost: 5.0
+
+  # dart coverage
+  - name: shelf
+    repo: https://github.com/dart-lang/shelf
+    license: BSD-3-Clause
+    pin: fb3f931d2c158d794e83c1b76b7be4b625db3c28
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - ai-defects
+        targets:
+          - pkgs/_shelf_compliance
+        cost: 4.0
+
+  # shell coverage
+  - name: sdkman-cli
+    repo: https://github.com/sdkman/sdkman-cli
+    license: Apache-2.0
+    pin: f02e5de113ea46a95e5e2fd795eabe6f2b7d4095
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        targets:
+          - src/main/bash
+        cost: 2.0
+
+  # c# coverage
+  - name: fastendpoints
+    repo: https://github.com/FastEndpoints/FastEndpoints
+    license: MIT
+    pin: 7b0678f7d2e3b44898d4c602b082835567332782
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
+          - ai-defects
+        targets:
+          - Src/Generator.Cli
+        cost: 6.0
+
+  # kotlin coverage
+  - name: ktor-samples
+    repo: https://github.com/ktorio/ktor-samples
+    license: Apache-2.0
+    pin: 69dcff3fa81daa85f936cfb7f17007761363c303
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - ai-defects
+        targets:
+          - filelisting/src
+          - httpbin/src
+        cost: 4.0
+
+  # php coverage
+  - name: slim
+    repo: https://github.com/slimphp/Slim
+    license: MIT
+    pin: 80900fb39cafce3ae53b18a2c4f642a122f03095
+    include_tools:
+      - skylos
+    tools:
+      skylos:
+        analyses:
+          - danger
+          - secrets
+          - ai-defects
+        targets:
+          - Slim
+        cost: 4.0
 
   # pydantic consumer, real secrets and danger
   - name: elementary

--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -577,6 +577,10 @@ projects:
           - danger
           - secrets
           - quality
+        # Unique at this pin; Skylos matches secret-scan excludes by path component.
+        args:
+          - --exclude
+          - elementary_output.json
         cost: 8.0
 
   # runtime-generated decorator wrappers

--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -75,9 +75,13 @@ projects:
           - rich
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         targets:
           - rich
-        cost: 5.0
+        cost: 7.0
 
   - name: pluggy
     repo: https://github.com/pytest-dev/pluggy
@@ -146,9 +150,13 @@ projects:
           - httpx
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         targets:
           - httpx
-        cost: 2.0
+        cost: 3.0
 
   # Shared with Skylos's pinned real-repository framework corpus.
   - name: pydantic
@@ -161,9 +169,13 @@ projects:
           - pydantic
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         targets:
           - pydantic
-        cost: 11.0
+        cost: 14.0
 
   - name: flask
     repo: https://github.com/pallets/flask
@@ -175,6 +187,10 @@ projects:
           - src/flask
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         targets:
           - src/flask
         cost: 3.0
@@ -189,6 +205,8 @@ projects:
           - src/_pytest
         cost: 1.0
       skylos:
+        analyses:
+          - danger
         targets:
           - src/_pytest
         cost: 12.0
@@ -204,9 +222,13 @@ projects:
           - src/black
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         targets:
           - src/black
-        cost: 3.0
+        cost: 4.0
 
   - name: requests
     repo: https://github.com/psf/requests
@@ -238,9 +260,12 @@ projects:
           - mitmproxy
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
         targets:
           - mitmproxy
-        cost: 19.0
+        cost: 23.0
 
   # Shared with Skylos's pinned real-repository framework corpus.
   - name: starlette
@@ -273,6 +298,10 @@ projects:
       - vulture
     tools:
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         targets:
           - packages
         cost: 2.0
@@ -385,6 +414,8 @@ projects:
           - bin/hooks
         cost: 2.0
       skylos:
+        analyses:
+          - quality
         targets:
           - copyparty/web
           - bin/hooks
@@ -537,11 +568,16 @@ projects:
     pin: a2000b045a3a9aed385cb27c0d7a1c71d667702b
     include_tools:
       - vulture
+      - skylos
     tools:
       vulture:
         cost: 1.0
       skylos:
-        cost: 6.0
+        analyses:
+          - danger
+          - secrets
+          - quality
+        cost: 8.0
 
   # runtime-generated decorator wrappers
   - name: beartype
@@ -554,7 +590,10 @@ projects:
       vulture:
         cost: 1.0
       skylos:
-        cost: 14.0
+        analyses:
+          - danger
+          - quality
+        cost: 15.0
 
   # Decorator and annotation-defined GraphQL schemas
   - name: strawberry
@@ -567,7 +606,10 @@ projects:
       vulture:
         cost: 2.0
       skylos:
-        cost: 16.0
+        analyses:
+          - danger
+          - secrets
+        cost: 19.0
 
   # settings-discovered components, signal handlers, middleware
   - name: scrapy
@@ -580,6 +622,8 @@ projects:
       vulture:
         cost: 2.0
       skylos:
+        analyses:
+          - secrets
         cost: 17.0
 
   # Paired Python model code and Typescript implementation
@@ -688,7 +732,11 @@ projects:
           - .
         cost: 1.0
       skylos:
-        cost: 8.0
+        analyses:
+          - danger
+          - secrets
+          - quality
+        cost: 9.0
 
   # Scale target: ~1,500 tracked Python files.
   - name: pandas
@@ -703,7 +751,10 @@ projects:
           - --min-confidence=100
         cost: 13.0
       skylos:
-        cost: 168.0
+        analyses:
+          - danger
+          - secrets
+        cost: 177.0
 
   # Widgets, layouts, and hooks wired through @expose_command and
   # hook.subscribe rather than direct calls. Has [tool.vulture]
@@ -722,10 +773,13 @@ projects:
           - libqtile
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
         args:
           - --exclude
           - test/configs/syntaxerr.py
-        cost: 19.0
+        cost: 20.0
 
   # Whitelist-module semantics.
   # Mirrored sync/async hierarchies and command-table dispatch.
@@ -744,7 +798,10 @@ projects:
           - whitelist.py
         cost: 2.0
       skylos:
-        cost: 36.0
+        analyses:
+          - danger
+          - secrets
+        cost: 40.0
 
   # Self-hosting: Vulture's own AST visitor, config, reporting, built-in
   # whitelists, and the tests encoding its supported Python constructs.
@@ -763,6 +820,10 @@ projects:
         expected_clean: true
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
+          - quality
         cost: 2.0
 
   # Self-hosting liveness_primer itself: invocation builder,
@@ -778,8 +839,11 @@ projects:
           - tests
         cost: 1.0
       skylos:
+        analyses:
+          - danger
+          - secrets
         targets:
           - liveness_primer
           - tests
         expected_clean: true
-        cost: 4.0
+        cost: 5.0


### PR DESCRIPTION
## Summary

Add 14 pinned, issue-backed projects to broaden Vulture regression coverage and Skylos language, liveness, quality, and security coverage. The final corpus configuration also expands Skylos analyses on low-cost existing targets and recalibrates declared Vulture and Skylos costs.

## What changed

- Add Remark, Bubble Tea, xarray, Meltano SDK, fluids, todo, copyparty, and Headroom for broader Python, JavaScript, Go, Rust, and TypeScript coverage.
- Add focused Java, Dart, shell, C#, Kotlin, and PHP targets through VeraDemo, Shelf, SDKMAN CLI, FastEndpoints, Ktor samples, and Slim.

VeraDemo contains deliberate positive controls for several Java security rules, adding a kind of corpus coverage that was previously sparse outside the pre-cleanup dead-code pins. Elementary includes real danger and secrets recall anchors.

## Skylos analyses and timing

“Added analyses” are the opt-in Skylos analyses enabled in addition to its default dead-code analysis. Costs are the final declared approximate CPU-second budgets for a paired base-and-head run on the reference machine. They were recalibrated from five-run benchmark data and rounded conservatively; they are selection budgets, not CI wall-clock promises.

`default` rows participate in a normal Skylos `--all` selection. `opt-in` rows have complete Skylos configuration and declared costs but require explicit `-k` selection or `--ignore-include-tools`.

| Selection | Project | Targets | Added analyses | Declared paired cost |
|---|---|---|---|---:|
| default | `attrs` | `src` | `danger`, `secrets`, `quality`, `ai-defects` | 4 s |
| default | `click` | `src/click` | `danger`, `secrets`, `quality`, `ai-defects` | 6 s |
| default | `jinja` | `src/jinja2` | `danger`, `secrets`, `quality`, `ai-defects` | 8 s |
| default | `rich` | `rich` | `danger`, `secrets`, `quality` | 7 s |
| default | `pluggy` | `src/pluggy` | `danger`, `secrets`, `quality`, `ai-defects` | 3 s |
| default | `more-itertools` | `more_itertools` | `danger`, `secrets`, `quality`, `ai-defects` | 5 s |
| default | `platformdirs` | `src/platformdirs` | `danger`, `secrets`, `quality`, `ai-defects` | 3 s |
| default | `httpx` | `httpx` | `danger`, `secrets`, `quality` | 3 s |
| default | `pydantic` | `pydantic` | `danger`, `secrets`, `quality` | 14 s |
| default | `flask` | `src/flask` | `danger`, `secrets`, `quality` | 3 s |
| default | `pytest` | `src/_pytest` | `danger` | 12 s |
| default | `black-pre-cleanup` | `src/black` | `danger`, `secrets`, `quality` | 4 s |
| default | `requests` | `src/requests` | `danger`, `secrets`, `quality`, `ai-defects` | 6 s |
| default | `mitmproxy-pre-cleanup` | `mitmproxy` | `danger`, `secrets` | 23 s |
| default | `starlette` | `starlette` | `danger`, `secrets`, `quality`, `ai-defects` | 7 s |
| default | `remark` | `packages` | `danger`, `secrets`, `quality` | 2 s |
| default | `bubbletea` | `.` | `danger`, `secrets`, `quality`, `ai-defects` | 18 s |
| default | `xarray` | `.` | `danger`, `secrets`, `quality`, `ai-defects` | 83 s |
| default | `meltano-sdk` | `singer_sdk`, `tests` | `danger`, `secrets`, `quality`, `ai-defects` | 20 s |
| default | `fluids` | `fluids` | `danger`, `secrets`, `quality`, `ai-defects` | 21 s |
| default | `todo` | `src/todo` | `danger`, `secrets`, `quality`, `ai-defects` | 6 s |
| default | `copyparty` | `copyparty/web`, `bin/hooks` | `quality` | 3 s |
| default | `headroom-rust` | `crates`, `sdk` | `danger`, `secrets`, `quality`, `ai-defects` | 32 s |
| default | `verademo` | `app/src/main/java` | `danger`, `secrets`, `quality`, `ai-defects` | 2 s |
| default | `shelf` | `pkgs/_shelf_compliance` | `danger`, `secrets`, `ai-defects` | 2 s |
| default | `sdkman-cli` | `src/main/bash` | `danger`, `secrets`, `quality`, `ai-defects` | 2 s |
| default | `fastendpoints` | `Src/Generator.Cli` | `danger`, `secrets`, `quality`, `ai-defects` | 2 s |
| default | `ktor-samples` | `filelisting/src`, `httpbin/src` | `danger`, `secrets`, `ai-defects` | 3 s |
| default | `slim` | `Slim` | `danger`, `secrets`, `ai-defects` | 3 s |
| default | `elementary` | `.` | `danger`, `secrets`, `quality` | 8 s |
| default | `liveness-primer` | `liveness_primer`, `tests` | `danger`, `secrets` | 5 s |
| opt-in | `beartype` | `.` | `danger`, `quality` | 15 s |
| opt-in | `strawberry` | `.` | `danger`, `secrets` | 19 s |
| opt-in | `scrapy` | `.` | `secrets` | 17 s |
| opt-in | `bokeh` | `.` | Default analysis only | 55 s |
| opt-in | `prowler-sdk` | `.` | Default analysis only | 368 s |
| opt-in | `mne-python` | `.` | Default analysis only | 62 s |
| opt-in | `mcp-context-forge` | `.` | Default analysis only | 264 s |
| opt-in | `psutil` | `.` | `danger`, `secrets`, `quality` | 9 s |
| opt-in | `pandas` | `.` | `danger`, `secrets` | 177 s |
| opt-in | `qtile` | `.` | `danger`, `secrets` | 20 s |
| opt-in | `redis-py` | `.` | `danger`, `secrets` | 40 s |
| opt-in | `vulture` | `.` | `danger`, `secrets`, `quality` | 2 s |

The normal Skylos selection declares **320 seconds** across 31 projects. Including all 12 opt-in configurations declares **1,368 seconds** across 43 projects.

## Validation

- `liveness-primer corpus validate`
- `liveness-primer corpus license-check`
- `prek run --all-files`

Closes #25
Closes #27
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #37
Closes #38
Closes #39
Closes #40
Closes #44
Closes #47
Closes #48
Closes #49
Closes #50

@duriantaco thanks for adding liveness_primer to your CI! What do you think of these added blast-radius sources to have at least some coverage all of skylos's nominally supported language, and adding scanning of all the rules? Any comments on what you think the policy for adding new skylos sources should be (it will also take a skylos PR eventually of course, so you will have to approve corpus additions either way, because you pinned the exact liveness_primer hash in your CI job).