### PR TITLE
feat(corpus): add Vulture regression targets

### DIFF
--- a/liveness_primer/data/corpus.yaml
+++ b/liveness_primer/data/corpus.yaml
@@ -221,3 +221,68 @@ projects:
         targets:
           - starlette
         cost: 10.0
+
+  # numerical and scientific python
+  - name: xarray
+    repo: https://github.com/pydata/xarray
+    license: Apache-2.0
+    pin: c2998a75ef32f6cf4d62cd946f2200ca953550d9
+    include_tools:
+      - vulture
+    tools:
+      vulture:
+        cost: 3.0
+
+  # sql and mock data coverage
+  - name: meltano-sdk
+    repo: https://github.com/meltano/sdk
+    license: Apache-2.0
+    pin: ef3a36bb3da8ff30a5f9d935da99a747dc135cad
+    include_tools:
+      - vulture
+    tools:
+      vulture:
+        targets:
+          - singer_sdk/
+          - tests/
+        cost: 1.0
+
+  # numerical python
+  - name: fluids
+    repo: https://github.com/CalebBell/fluids
+    license: MIT
+    pin: 5fa218f9c15f62e2a7f864b97991f4837ddeefe7
+    include_tools:
+      - vulture
+    tools:
+      vulture:
+        targets:
+          - fluids
+        cost: 2.0
+
+  # sql injection coverage
+  - name: todo
+    repo: https://github.com/maltekliemann/todo
+    license: MIT
+    pin: f122c1722b673a482cb98f97680caccf99102d7a
+    include_tools:
+      - vulture
+    tools:
+      vulture:
+        targets:
+          - src/todo/domain/status.py
+        cost: 1.0
+
+  # javascript and python coverage
+  - name: copyparty
+    repo: https://github.com/9001/copyparty
+    license: MIT
+    pin: 6115eb452d2c2bbdeef5d19098fac17db69ddaa8
+    include_tools:
+      - vulture
+    tools:
+      vulture:
+        targets:
+          - copyparty
+          - bin/hooks
+        cost: 2.0


### PR DESCRIPTION
## Summary

Add five pinned, issue-backed projects for Vulture regression coverage only. This commit is also the shared ancestor for the broader corpus expansion in #41.

This PR intentionally does not close the underlying corpus proposal issues; issue closure remains with the full multi-tool PR.

## What changed

- Add xarray, Meltano SDK, fluids, todo, and copyparty with the Vulture targets and costs from #41.
- Restrict every new project with `include_tools: [vulture]`; none declares Skylos settings or participates in Skylos runs.

## Verification

```text
corpus validate: 20 projects OK
corpus license-check: all 20 licenses confirmed
pytest: 574 passed, 3 skipped
prek run --all-files: passed
```

## Checklist

- [x] The full pytest suite passes locally.
- [x] `prek run --all-files` passes locally.
- [x] The corpus model verifies that explicit `include_tools` excludes Skylos.
- [x] No public Python API or report schema changed.
- [x] **Corpus changed:** `corpus validate` and `corpus license-check` pass; new entries are GitHub-hosted, allowlisted, and pinned to a full commit SHA.

## AI assistance

Details: Codex prepared and validated the corpus split and coordinated its commit ancestry with #41.

## Notes for the reviewer

Please merge this PR with **Create a merge commit**, rather than squash-merging it, so commit `018557f` remains a common ancestor of #41 and the latter stays conflict-free.
