### PR TITLE
docs: make liveness review skill opt-in

### DIFF
--- a/.agents/skills/review-liveness-pr/SKILL.md
+++ b/.agents/skills/review-liveness-pr/SKILL.md
@@ -1,9 +1,16 @@
 ---
 name: review-liveness-pr
-description: Review an existing liveness_primer JSON artifact against a pull request's stated intent and produce a concise advisory report with one conclusion, optional verdict flags, confidence, review priority, and specific finding evidence. Use for pull-request or CI review when a liveness_primer report, PR description, diff, and relevant source are available. Support every liveness_primer adapter. Never rerun the detector or liveness_primer.
+description: CI or manual invocation only. Use only when the user explicitly invokes $review-liveness-pr or a designated liveness_primer CI workflow invokes it. Never auto-select this skill for a general pull-request review, even when a liveness_primer artifact is available.
 ---
 
 # Review a liveness_primer pull request
+
+## Activation boundary
+
+Use this skill only after an explicit ``$review-liveness-pr`` invocation or
+from the designated liveness_primer CI workflow. A general pull-request review
+does not authorize this workflow, even when a liveness_primer artifact is
+available.
 
 Produce a read-only advisory review of an existing liveness_primer JSON report.
 Return concise GitHub-flavored Markdown followed by an embedded machine-readable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,11 @@ Write very briefy, numpy style docstrings, which checked by the `pydoclint` CI w
 A `skylos` CI workflow is used for dead code detection.
 Unit tests are `pytest` style. Unit tests should aim for full branch and line coverage with non-vacuous tests.
 A ``coverage.py` CI workflow enforces thorough testing coverage.
+
+## Skill activation
+
+- Treat `review-liveness-pr` as opt-in only. Do not invoke it unless the user
+  explicitly writes `$review-liveness-pr` or the caller is the designated
+  liveness_primer CI workflow.
+- A request to review a pull request is a normal review request, even when a
+  liveness_primer artifact is available.


### PR DESCRIPTION
## Summary

Restrict `review-liveness-pr` to explicit `$review-liveness-pr` requests or the designated CI workflow, so ordinary PR reviews do not acquire its artifact-verdict format.

## What changed

- Narrowed the skill metadata and added an activation boundary.
- Added the same opt-in rule to `AGENTS.md` as a repository guardrail.

## Verification

```text
prek run --all-files
```

## Checklist

- [x] `prek run --all-files` passes locally.
- [x] No code or public API behavior changed.
- [x] `CHANGELOG.md` is not needed for this internal instruction change.

## AI assistance

Details: Drafted and verified with Codex.

## Notes for the reviewer

The skill remains available for explicit manual use and CI; it is no longer a general PR-review trigger.