### PR TITLE
fix(skylos): ingest unused file findings

### DIFF
--- a/.contracts/human_readable_reporting.md
+++ b/.contracts/human_readable_reporting.md
@@ -91,6 +91,13 @@ The Skylos JSON buckets currently ingested by `liveness_primer` map as follows:
 | `unused_classes` | `SKY-U004` | unused class or type |
 | `unused_parameters` | `SKY-U006` | unused parameter |
 
+The `unused_files` bucket is also ingested but has no bucket fallback: it is a multi-rule
+bucket whose entries every supported Skylos revision stamps with an explicit `rule_id`
+(`SKY-E002` for an empty or docstring-only Python file, `SKY-E003` for a TypeScript or
+JavaScript file no other file imports). The adapter must require the explicit `rule_id` on
+each `unused_files` entry and reject an entry without one as malformed; defaulting one
+rule's code onto the other's entries would corrupt the finding identity.
+
 The mapping is adapter normalization and must be covered by recorded-output tests. If a
 supported Skylos revision changes the documented mapping, the adapter must be updated rather
 than silently retaining a stale code.
@@ -206,9 +213,13 @@ occurrence:
 - context beyond the `N`-line evidence budget was never requested and is not counted as
   omitted;
 - a point finding near end-of-file has `omitted_lines = 0` when fewer than `N` source lines
-  exist; and
+  exist;
 - missing, unreadable, non-regular, or out-of-range source produces no excerpt and a bounded
-  report warning rather than fabricated text.
+  report warning rather than fabricated text; and
+- a file-level finding (kind `file`) on a file with zero source lines produces no excerpt and
+  no warning: the emptiness is the reported condition itself (e.g. Skylos `SKY-E002`), so the
+  occurrence is intentionally source-less and must not spend the warning budget that exists
+  to surface genuine source anomalies.
 
 Source evidence is derived review context. It must not participate in finding identity, the
 canonical occurrence key, or changed-field classification. The corpus is identical across

--- a/.contracts/human_readable_reporting.md
+++ b/.contracts/human_readable_reporting.md
@@ -81,6 +81,12 @@ An adapter must populate `rule_id` using the following precedence:
 An adapter must not infer a rule ID from free-form message text. The human renderer displays
 an absent rule ID as `-`; it must not invent a tool-specific code.
 
+One documented exception to step 3: when a bucket is multi-rule and every supported detector
+revision stamps the rule ID explicitly on each entry (Skylos `unused_files`, below), a
+missing explicit rule ID is a malformed entry the adapter must reject, not a `None` — no
+bucket mapping exists, and accepting the entry rule-less would let the same finding surface
+under two identities across revisions.
+
 The Skylos JSON buckets currently ingested by `liveness_primer` map as follows:
 
 | Skylos bucket | Rule ID | Meaning |
@@ -216,10 +222,12 @@ occurrence:
   exist;
 - missing, unreadable, non-regular, or out-of-range source produces no excerpt and a bounded
   report warning rather than fabricated text; and
-- a file-level finding (kind `file`) on a file with zero source lines produces no excerpt and
-  no warning: the emptiness is the reported condition itself (e.g. Skylos `SKY-E002`), so the
-  occurrence is intentionally source-less and must not spend the warning budget that exists
-  to surface genuine source anomalies.
+- a finding in the normalized unused-file shape — kind `file`, no symbol, and a point span at
+  line 1 — on a file with zero source lines produces no excerpt and no warning: the emptiness
+  is the reported condition itself (e.g. Skylos `SKY-E002`), so the occurrence is
+  intentionally source-less and must not spend the warning budget that exists to surface
+  genuine source anomalies. Any other occurrence claiming source in an empty file — a symbol
+  finding, or a file finding pointing past line 1 — remains a warned anomaly.
 
 Source evidence is derived review context. It must not participate in finding identity, the
 canonical occurrence key, or changed-field classification. The corpus is identical across
@@ -362,7 +370,9 @@ sufficient evidence.
 
 For `new`, the head excerpt follows the summary row. For `dropped` and `changed`, the base
 excerpt follows it; both sides of a `changed` pair share their identity-pinned span, so one
-excerpt always suffices. If the excerpt cannot be collected, the bounded warning records it.
+excerpt always suffices. If the excerpt cannot be collected, the bounded warning records it —
+except for an intentionally source-less occurrence (§3.3's normalized unused-file shape on a
+zero-line file), which has no excerpt and no warning by design.
 
 A finding and its evidence must read as one visually coherent block. The continuation region
 is indented two cells from the left margin — not aligned under the location column, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Report and manifest payloads carry their own `schema_version`, versioned
 independently of the package version; `liveness-primer --version` prints both.
 
+## [Unreleased]
+
+### Fixed
+
+- The Skylos adapter now ingests `unused_files` (`SKY-E002` and `SKY-E003`)
+  findings instead of silently omitting file-level dead-code changes from
+  comparisons.
+
 ## [0.1.0] - 2026-08-14
 
 This is the first release version of `liveness_primer`, so everything is new.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ independently of the package version; `liveness-primer --version` prints both.
 
 - The Skylos adapter now ingests `unused_files` (`SKY-E002` and `SKY-E003`)
   findings instead of silently omitting file-level dead-code changes from
-  comparisons.
+  comparisons. The bucket is multi-rule and every supported Skylos revision
+  stamps each entry's rule ID explicitly, so the adapter requires the
+  explicit `rule_id` rather than defaulting one rule's code onto the
+  other's entries.
+- A file-level finding on a file with zero source lines (e.g. `SKY-E002`)
+  is intentionally source-less: it no longer spends the bounded
+  source-warning budget on the expected emptiness, keeping the budget for
+  genuine source anomalies.
 
 ## [0.1.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ independently of the package version; `liveness-primer --version` prints both.
   stamps each entry's rule ID explicitly, so the adapter requires the
   explicit `rule_id` rather than defaulting one rule's code onto the
   other's entries.
-- A file-level finding on a file with zero source lines (e.g. `SKY-E002`)
-  is intentionally source-less: it no longer spends the bounded
-  source-warning budget on the expected emptiness, keeping the budget for
-  genuine source anomalies.
+- A finding in the normalized unused-file shape — kind `file`, no symbol,
+  a point span at line 1 — on a file with zero source lines (e.g.
+  `SKY-E002`) is intentionally source-less: it no longer spends the
+  bounded source-warning budget on the expected emptiness, keeping the
+  budget for genuine source anomalies. Any other occurrence claiming
+  source in an empty file still warns.
 
 ## [0.1.0] - 2026-08-14
 

--- a/liveness_primer/report/source.py
+++ b/liveness_primer/report/source.py
@@ -8,7 +8,9 @@ from the detector's ``raw_excerpt``. Extraction goes through the bounded,
 containment-enforcing filesystem helpers so corpus-controlled symlinks,
 special files, oversized files, and undecodable bytes cannot bypass the
 report trust boundary. Missing or out-of-range source produces no excerpt
-and a bounded report warning rather than fabricated text.
+and a bounded report warning rather than fabricated text; a file-level
+finding on a file with zero source lines is intentionally source-less and
+produces neither.
 """
 
 import re
@@ -239,6 +241,12 @@ def collect_source_evidence(
             lines = cache.lines(diff.path)
             if isinstance(lines, str):
                 warnings[f'{diff.path}: {lines}'] = None
+                continue
+            # A file-level finding on a file with zero source lines (e.g.
+            # skylos SKY-E002) reports the emptiness itself: the file is
+            # intentionally source-less, not anomalous, so there is no
+            # excerpt and no warning (reporting contract §3.3).
+            if diff.kind == 'file' and not lines:
                 continue
             excerpt, reason = extract_excerpt(
                 lines,

--- a/liveness_primer/report/source.py
+++ b/liveness_primer/report/source.py
@@ -8,9 +8,9 @@ from the detector's ``raw_excerpt``. Extraction goes through the bounded,
 containment-enforcing filesystem helpers so corpus-controlled symlinks,
 special files, oversized files, and undecodable bytes cannot bypass the
 report trust boundary. Missing or out-of-range source produces no excerpt
-and a bounded report warning rather than fabricated text; a file-level
-finding on a file with zero source lines is intentionally source-less and
-produces neither.
+and a bounded report warning rather than fabricated text; a symbol-less
+file-level finding pointing at line 1 of a file with zero source lines is
+intentionally source-less and produces neither.
 """
 
 import re
@@ -245,8 +245,13 @@ def collect_source_evidence(
             # A file-level finding on a file with zero source lines (e.g.
             # skylos SKY-E002) reports the emptiness itself: the file is
             # intentionally source-less, not anomalous, so there is no
-            # excerpt and no warning (reporting contract §3.3).
-            if diff.kind == 'file' and not lines:
+            # excerpt and no warning (reporting contract §3.3). Only the
+            # normalized unused-file shape qualifies — no symbol and a
+            # point span at line 1; anything else claiming source in an
+            # empty file remains a warned anomaly.
+            file_level = diff.kind == 'file' and diff.symbol is None
+            point_at_start = occurrence.start_line == occurrence.end_line == 1
+            if file_level and point_at_start and not lines:
                 continue
             excerpt, reason = extract_excerpt(
                 lines,

--- a/liveness_primer/testing/fake_detector.py
+++ b/liveness_primer/testing/fake_detector.py
@@ -42,14 +42,14 @@ class FakeFinding:
     confidence : int
         Confidence percentage.
     bucket : str
-        Skylos array the finding lands in (skylos format only); the
-        diagnostic buckets emit the diagnostic entry shape.
+        Skylos array the finding lands in (skylos format only); diagnostic
+        buckets and ``unused_files`` emit their respective entry shapes.
     rule_id : str | None
         Explicit detector rule ID (skylos format only).
     severity : str | None
-        Severity label (skylos diagnostic buckets only).
+        Severity label (skylos diagnostic or unused-file buckets only).
     message : str | None
-        Message override (skylos diagnostic buckets only).
+        Message override (skylos diagnostic or unused-file buckets only).
     """
 
     path: str
@@ -78,10 +78,21 @@ class FakeFinding:
         Returns
         -------
         dict[str, object]
-            The dead-code entry shape, or the diagnostic shape for the
-            diagnostic buckets; optional fields are present only when
-            scripted.
+            The symbol-level dead-code entry shape, or the dedicated shape
+            for diagnostic and unused-file buckets; optional fields are
+            present only when scripted.
         """
+        if self.bucket == 'unused_files':
+            unused_file: dict[str, object] = {
+                'message': self.message if self.message is not None else f"Unused file '{self.path}'",
+                'file': self.path,
+                'line': self.line,
+            }
+            if self.rule_id is not None:
+                unused_file['rule_id'] = self.rule_id
+            if self.severity is not None:
+                unused_file['severity'] = self.severity
+            return unused_file
         if self.bucket in DIAGNOSTIC_KINDS:
             diagnostic: dict[str, object] = {
                 'message': self.message if self.message is not None else f"dangerous use of '{self.symbol}'",

--- a/liveness_primer/testing/fake_detector.py
+++ b/liveness_primer/testing/fake_detector.py
@@ -25,8 +25,10 @@ from liveness_primer.tools.skylos import DEAD_CODE_KEYS, DIAGNOSTIC_KINDS
 FakeFormat = Literal['vulture', 'skylos']
 
 # File suffixes real skylos reports as SKY-E003 (unused TypeScript or
-# JavaScript file); every other unused-file path is an empty-file SKY-E002.
-_TYPESCRIPT_SUFFIXES = ('.ts', '.tsx', '.js', '.jsx')
+# JavaScript file), matching its own TS/JS extension list including the
+# .mts/.cts/.mjs/.cjs module variants; every other unused-file path is an
+# empty-file SKY-E002.
+_TYPESCRIPT_SUFFIXES = ('.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs')
 
 
 @dataclass(frozen=True, slots=True)

--- a/liveness_primer/testing/fake_detector.py
+++ b/liveness_primer/testing/fake_detector.py
@@ -20,9 +20,13 @@ from pathlib import Path
 from typing import Literal
 
 from liveness_primer.filesystem import atomic_write_text
-from liveness_primer.tools.skylos import BUCKET_RULE_IDS, DIAGNOSTIC_KINDS
+from liveness_primer.tools.skylos import DEAD_CODE_KEYS, DIAGNOSTIC_KINDS
 
 FakeFormat = Literal['vulture', 'skylos']
+
+# File suffixes real skylos reports as SKY-E003 (unused TypeScript or
+# JavaScript file); every other unused-file path is an empty-file SKY-E002.
+_TYPESCRIPT_SUFFIXES = ('.ts', '.tsx', '.js', '.jsx')
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,7 +49,10 @@ class FakeFinding:
         Skylos array the finding lands in (skylos format only); diagnostic
         buckets and ``unused_files`` emit their respective entry shapes.
     rule_id : str | None
-        Explicit detector rule ID (skylos format only).
+        Explicit detector rule ID (skylos format only). ``unused_files``
+        entries always carry one: when unscripted it is inferred from the
+        path suffix (SKY-E003 for TypeScript/JavaScript, SKY-E002
+        otherwise), because the adapter rejects a rule-less entry.
     severity : str | None
         Severity label (skylos diagnostic or unused-file buckets only).
     message : str | None
@@ -83,13 +90,18 @@ class FakeFinding:
             present only when scripted.
         """
         if self.bucket == 'unused_files':
+            # Every supported skylos revision stamps the rule ID explicitly
+            # on unused-file entries (the adapter rejects an entry without
+            # one), so an unscripted ID is inferred the way real skylos
+            # assigns the rules: SKY-E003 for a TypeScript/JavaScript file,
+            # SKY-E002 for an empty file otherwise.
+            inferred = 'SKY-E003' if self.path.endswith(_TYPESCRIPT_SUFFIXES) else 'SKY-E002'
             unused_file: dict[str, object] = {
+                'rule_id': self.rule_id if self.rule_id is not None else inferred,
                 'message': self.message if self.message is not None else f"Unused file '{self.path}'",
                 'file': self.path,
                 'line': self.line,
             }
-            if self.rule_id is not None:
-                unused_file['rule_id'] = self.rule_id
             if self.severity is not None:
                 unused_file['severity'] = self.severity
             return unused_file
@@ -277,7 +289,7 @@ def _emit_skylos(findings: Sequence[FakeFinding]) -> int:
     int
         The default skylos exit code: 0.
     """
-    document: dict[str, list[dict[str, object]]] = {key: [] for key in BUCKET_RULE_IDS}
+    document: dict[str, list[dict[str, object]]] = {key: [] for key in DEAD_CODE_KEYS}
     for finding in findings:
         document.setdefault(finding.bucket, []).append(finding.skylos_entry())
     sys.stdout.write(json.dumps(document, indent=2) + '\n')

--- a/liveness_primer/testing/fake_detector.py
+++ b/liveness_primer/testing/fake_detector.py
@@ -24,11 +24,9 @@ from liveness_primer.tools.skylos import DEAD_CODE_KEYS, DIAGNOSTIC_KINDS
 
 FakeFormat = Literal['vulture', 'skylos']
 
-# File suffixes real skylos reports as SKY-E003 (unused TypeScript or
-# JavaScript file), matching its own TS/JS extension list including the
-# .mts/.cts/.mjs/.cjs module variants; every other unused-file path is an
-# empty-file SKY-E002.
-_TYPESCRIPT_SUFFIXES = ('.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs')
+# Severity every supported skylos revision stamps on an unused-file entry;
+# a scripted label overrides it.
+_UNUSED_FILE_SEVERITY = 'LOW'
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,12 +49,15 @@ class FakeFinding:
         Skylos array the finding lands in (skylos format only); diagnostic
         buckets and ``unused_files`` emit their respective entry shapes.
     rule_id : str | None
-        Explicit detector rule ID (skylos format only). ``unused_files``
-        entries always carry one: when unscripted it is inferred from the
-        path suffix (SKY-E003 for TypeScript/JavaScript, SKY-E002
-        otherwise), because the adapter rejects a rule-less entry.
+        Explicit detector rule ID (skylos format only). Required for
+        ``unused_files``: the bucket is multi-rule and each of its rules
+        names a condition the fake cannot observe (SKY-E002 emptiness,
+        SKY-E003 import reachability), so the script states the rule rather
+        than the fake guessing one from the path.
     severity : str | None
         Severity label (skylos diagnostic or unused-file buckets only).
+        Unscripted ``unused_files`` entries carry the ``LOW`` every
+        supported skylos revision stamps on them.
     message : str | None
         Message override (skylos diagnostic or unused-file buckets only).
     """
@@ -90,23 +91,30 @@ class FakeFinding:
             The symbol-level dead-code entry shape, or the dedicated shape
             for diagnostic and unused-file buckets; optional fields are
             present only when scripted.
+
+        Raises
+        ------
+        ValueError
+            If an ``unused_files`` finding carries no explicit rule ID.
         """
         if self.bucket == 'unused_files':
             # Every supported skylos revision stamps the rule ID explicitly
-            # on unused-file entries (the adapter rejects an entry without
-            # one), so an unscripted ID is inferred the way real skylos
-            # assigns the rules: SKY-E003 for a TypeScript/JavaScript file,
-            # SKY-E002 for an empty file otherwise.
-            inferred = 'SKY-E003' if self.path.endswith(_TYPESCRIPT_SUFFIXES) else 'SKY-E002'
-            unused_file: dict[str, object] = {
-                'rule_id': self.rule_id if self.rule_id is not None else inferred,
+            # on unused-file entries and the adapter rejects an entry
+            # without one, so the fake never emits a rule-less entry. The
+            # rule is not derivable from the path either: real skylos picks
+            # SKY-E002 or SKY-E003 by a file's emptiness and import
+            # reachability, which a scripted fake cannot observe. The entry
+            # shape carries no symbol, kind, or confidence.
+            if self.rule_id is None:
+                msg = f'scripted unused_files finding for {self.path!r} needs an explicit rule_id'
+                raise ValueError(msg)
+            return {
+                'rule_id': self.rule_id,
                 'message': self.message if self.message is not None else f"Unused file '{self.path}'",
                 'file': self.path,
                 'line': self.line,
+                'severity': self.severity if self.severity is not None else _UNUSED_FILE_SEVERITY,
             }
-            if self.severity is not None:
-                unused_file['severity'] = self.severity
-            return unused_file
         if self.bucket in DIAGNOSTIC_KINDS:
             diagnostic: dict[str, object] = {
                 'message': self.message if self.message is not None else f"dangerous use of '{self.symbol}'",

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -24,8 +24,10 @@ from liveness_primer.tools.base import (
     normalize_finding_path,
 )
 
-# Dead-code finding arrays in the skylos JSON document
-_DEAD_CODE_KEYS = (
+# Dead-code finding arrays in the skylos JSON document; the complete
+# always-ingested bucket list, public so the fake detector emits the same
+# document shape as a real skylos run.
+DEAD_CODE_KEYS = (
     'unused_functions',
     'unused_imports',
     'unused_classes',
@@ -67,12 +69,15 @@ _NEUTRAL_CONFIG = Path(__file__).with_name('skylos_neutral_config.toml')
 # the pass cannot on its own starve the rest of the run.
 _GREP_BUDGET_SECONDS = '150'
 
-# Documented, versioned mapping from each ingested skylos structured output
-# bucket to its canonical rule ID (reporting contract §3.1). A rule ID
-# explicitly present on the detector finding takes precedence; a rule ID is
-# never inferred from free-form message text. If a supported skylos revision
-# changes the documented mapping, this table must be updated rather than
-# silently retaining a stale code.
+# Documented, versioned mapping from each ingested single-rule skylos
+# symbol bucket to its canonical rule ID (reporting contract §3.1). A rule
+# ID explicitly present on the detector finding takes precedence; a rule ID
+# is never inferred from free-form message text. The multi-rule
+# ``unused_files`` bucket is deliberately absent: it has no canonical
+# bucket-level code, so its entries must carry their explicit rule IDs
+# (see ``_SkylosUnusedFileEntry``). If a supported skylos revision changes
+# the documented mapping, this table must be updated rather than silently
+# retaining a stale code.
 BUCKET_RULE_IDS = {
     'unused_functions': 'SKY-U001',
     'unused_imports': 'SKY-U002',
@@ -239,7 +244,7 @@ class SkylosAdapter:
         if not isinstance(document, dict):
             msg = 'skylos output is not a JSON object'
             raise AdapterError(msg)
-        result_keys = (*_DEAD_CODE_KEYS, *(bucket for bucket in DIAGNOSTIC_KINDS if bucket in selected))
+        result_keys = (*DEAD_CODE_KEYS, *(bucket for bucket in DIAGNOSTIC_KINDS if bucket in selected))
         findings: list[Finding] = []
         for key in result_keys:
             bucket = document.get(key, [])

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -25,7 +25,14 @@ from liveness_primer.tools.base import (
 )
 
 # Dead-code finding arrays in the skylos JSON document
-_DEAD_CODE_KEYS = ('unused_functions', 'unused_imports', 'unused_classes', 'unused_variables', 'unused_parameters')
+_DEAD_CODE_KEYS = (
+    'unused_functions',
+    'unused_imports',
+    'unused_classes',
+    'unused_variables',
+    'unused_parameters',
+    'unused_files',
+)
 
 # Diagnostic arrays, each emitted only under its opt-in analysis flag,
 # mapped to the normalized kind stamped onto its findings. Entries carry a
@@ -72,6 +79,7 @@ BUCKET_RULE_IDS = {
     'unused_variables': 'SKY-U003',
     'unused_classes': 'SKY-U004',
     'unused_parameters': 'SKY-U006',
+    'unused_files': 'SKY-E002',
 }
 
 
@@ -105,6 +113,18 @@ class _SkylosDiagnosticEntry(BaseModel):
     line: int
     symbol: str | None = None
     name: str | None = None
+
+
+class _SkylosUnusedFileEntry(BaseModel):
+    """One unused-file entry from a skylos JSON array (untrusted input)."""
+
+    model_config = ConfigDict(frozen=True, extra='ignore')
+
+    rule_id: str | None = None
+    severity: str | None = None
+    message: str
+    file: str
+    line: int
 
 
 class SkylosAdapter:
@@ -219,7 +239,12 @@ class SkylosAdapter:
             if not isinstance(bucket, list):
                 msg = f'skylos key {key!r} is not an array'
                 raise AdapterError(msg)
-            parse_entry = _parse_diagnostic_entry if key in DIAGNOSTIC_KINDS else _parse_entry
+            if key == 'unused_files':
+                parse_entry = _parse_unused_file_entry
+            elif key in DIAGNOSTIC_KINDS:
+                parse_entry = _parse_diagnostic_entry
+            else:
+                parse_entry = _parse_entry
             findings.extend(parse_entry(raw, key=key, project=project, root=root) for raw in bucket)
         if output.returncode not in SkylosAdapter.success_exit_codes and not findings:
             msg = 'failed skylos output has no findings in recognized result buckets'
@@ -269,6 +294,51 @@ def _parse_entry(raw: object, *, key: str, project: str, root: Path) -> Finding:
         confidence=entry.confidence,
         # An explicit detector rule ID wins; the documented bucket mapping
         # is the fallback (reporting contract §3.1).
+        rule_id=entry.rule_id if entry.rule_id is not None else BUCKET_RULE_IDS.get(key),
+        raw_excerpt=json.dumps(entry.model_dump(), sort_keys=True),
+    )
+
+
+def _parse_unused_file_entry(raw: object, *, key: str, project: str, root: Path) -> Finding:
+    """Convert one unused-file entry into a finding.
+
+    Parameters
+    ----------
+    raw : object
+        Untrusted JSON entry.
+    key : str
+        Array name the entry came from, for error context.
+    project : str
+        Corpus project name to stamp onto the finding.
+    root : Path
+        Checkout directory skylos analyzed.
+
+    Returns
+    -------
+    Finding
+        The normalized file-level finding.
+
+    Raises
+    ------
+    AdapterError
+        If the entry does not carry the guaranteed skylos fields.
+    """
+    try:
+        entry = _SkylosUnusedFileEntry.model_validate(raw)
+    except ValidationError as exc:
+        msg = f'malformed skylos entry in {key!r}: {exc}'
+        raise AdapterError(msg) from exc
+    line = max(entry.line, 1)
+    return Finding(
+        tool=SkylosAdapter.name,
+        project=project,
+        path=normalize_finding_path(entry.file, root),
+        symbol=None,
+        kind='file',
+        message=entry.message,
+        start_line=line,
+        end_line=line,
+        severity=entry.severity,
         rule_id=entry.rule_id if entry.rule_id is not None else BUCKET_RULE_IDS.get(key),
         raw_excerpt=json.dumps(entry.model_dump(), sort_keys=True),
     )

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -79,7 +79,6 @@ BUCKET_RULE_IDS = {
     'unused_variables': 'SKY-U003',
     'unused_classes': 'SKY-U004',
     'unused_parameters': 'SKY-U006',
-    'unused_files': 'SKY-E002',
 }
 
 
@@ -116,11 +115,19 @@ class _SkylosDiagnosticEntry(BaseModel):
 
 
 class _SkylosUnusedFileEntry(BaseModel):
-    """One unused-file entry from a skylos JSON array (untrusted input)."""
+    """One unused-file entry from a skylos JSON array (untrusted input).
+
+    ``unused_files`` is a multi-rule bucket (``SKY-E002`` empty file,
+    ``SKY-E003`` unused TypeScript/JavaScript file) and every supported
+    skylos revision stamps the rule ID explicitly on each entry, so
+    ``rule_id`` is a guaranteed field: no bucket fallback exists, and
+    defaulting one rule's code onto the other's entries would corrupt the
+    finding identity (reporting contract §3.1).
+    """
 
     model_config = ConfigDict(frozen=True, extra='ignore')
 
-    rule_id: str | None = None
+    rule_id: str
     severity: str | None = None
     message: str
     file: str
@@ -339,7 +346,7 @@ def _parse_unused_file_entry(raw: object, *, key: str, project: str, root: Path)
         start_line=line,
         end_line=line,
         severity=entry.severity,
-        rule_id=entry.rule_id if entry.rule_id is not None else BUCKET_RULE_IDS.get(key),
+        rule_id=entry.rule_id,
         raw_excerpt=json.dumps(entry.model_dump(), sort_keys=True),
     )
 

--- a/tests/fixtures/skylos_output.json
+++ b/tests/fixtures/skylos_output.json
@@ -32,6 +32,24 @@
       "type": "class"
     }
   ],
+  "unused_files": [
+    {
+      "category": "DEAD_CODE",
+      "file": "pkg/blank.py",
+      "line": 1,
+      "message": "Empty Python file (no code, or docstring-only)",
+      "rule_id": "SKY-E002",
+      "severity": "LOW"
+    },
+    {
+      "category": "DEAD_CODE",
+      "file": "pkg/orphan.ts",
+      "line": 1,
+      "message": "Unused TypeScript/JavaScript file (not imported by any other file)",
+      "rule_id": "SKY-E003",
+      "severity": "LOW"
+    }
+  ],
   "unused_functions": [
     {
       "basename": "mod.py",

--- a/tests/fixtures/skylos_output.json
+++ b/tests/fixtures/skylos_output.json
@@ -26,31 +26,31 @@
       "changed_files_only": false,
       "complete_repository": false,
       "excluded_folders": [
-        ".coverage",
-        "venv",
-        "vendor",
         ".hg",
+        "dist",
         ".tox",
-        "htmlcov",
         ".git",
-        "__pycache__",
-        ".svn",
-        "*.egg-info",
-        ".pytest_cache",
-        ".mypy_cache",
-        "node_modules",
-        ".idea",
-        ".next",
-        ".nuxt",
-        ".venv",
-        ".turbo",
-        "build",
         ".vscode",
-        "dist"
+        ".pytest_cache",
+        ".turbo",
+        ".coverage",
+        ".next",
+        ".idea",
+        ".nuxt",
+        "venv",
+        "__pycache__",
+        "htmlcov",
+        "build",
+        ".svn",
+        "node_modules",
+        "*.egg-info",
+        ".venv",
+        "vendor",
+        ".mypy_cache"
       ],
       "kind": "repository_root_with_exclusions",
-      "repository_root": ".",
-      "scan_path": "."
+      "repository_root": "/checkout",
+      "scan_path": "/checkout"
     },
     "dead_code_evidence": {
       "candidate_decisions": {
@@ -70,27 +70,27 @@
       "rescued_count": 0
     },
     "excluded_folders": [
-      ".coverage",
-      "venv",
-      "vendor",
       ".hg",
+      "dist",
       ".tox",
-      "htmlcov",
       ".git",
-      "__pycache__",
-      ".svn",
-      "*.egg-info",
-      ".pytest_cache",
-      ".mypy_cache",
-      "node_modules",
-      ".idea",
-      ".next",
-      ".nuxt",
-      ".venv",
-      ".turbo",
-      "build",
       ".vscode",
-      "dist"
+      ".pytest_cache",
+      ".turbo",
+      ".coverage",
+      ".next",
+      ".idea",
+      ".nuxt",
+      "venv",
+      "__pycache__",
+      "htmlcov",
+      "build",
+      ".svn",
+      "node_modules",
+      "*.egg-info",
+      ".venv",
+      "vendor",
+      ".mypy_cache"
     ],
     "grade_categories": [
       "dead_code"
@@ -639,7 +639,7 @@
       "dead_code_reason_tags": [
         "top_level_execution"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "line": 17,
       "loc": 10,
       "name": "pkg.mod.Greeter",
@@ -714,7 +714,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "line": 24,
       "loc": 3,
       "name": "pkg.mod.Greeter.farewell",
@@ -766,7 +766,7 @@
       "dead_code_reason_tags": [
         "static_reference"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "line": 20,
       "loc": 3,
       "name": "pkg.mod.Greeter.greet",
@@ -841,7 +841,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "line": 7,
       "loc": 3,
       "name": "pkg.mod.orphan",
@@ -887,7 +887,7 @@
       "dead_code_reason_tags": [
         "static_reference"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "line": 12,
       "loc": 3,
       "name": "pkg.mod.used",
@@ -960,7 +960,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/shapes.py",
+      "file": "/checkout/pkg/shapes.py",
       "line": 12,
       "loc": 6,
       "name": "pkg.shapes.Hexagon",
@@ -1008,7 +1008,7 @@
       "dead_code_reason_tags": [
         "grep_rescue"
       ],
-      "file": "pkg/shapes.py",
+      "file": "/checkout/pkg/shapes.py",
       "line": 15,
       "loc": 3,
       "name": "pkg.shapes.Hexagon.area",
@@ -1048,7 +1048,7 @@
       "dead_code_reason_tags": [
         "static_reference"
       ],
-      "file": "pkg/shapes.py",
+      "file": "/checkout/pkg/shapes.py",
       "line": 4,
       "loc": 6,
       "name": "pkg.shapes.Square",
@@ -1098,7 +1098,7 @@
       "dead_code_reason_tags": [
         "static_reference"
       ],
-      "file": "pkg/shapes.py",
+      "file": "/checkout/pkg/shapes.py",
       "line": 7,
       "loc": 3,
       "name": "pkg.shapes.Square.area",
@@ -1192,7 +1192,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/shapes.py",
+      "file": "/checkout/pkg/shapes.py",
       "full_name": "pkg.shapes.Hexagon",
       "line": 12,
       "name": "Hexagon",
@@ -1204,7 +1204,7 @@
   "unused_files": [
     {
       "category": "DEAD_CODE",
-      "file": "pkg/blank.py",
+      "file": "/checkout/pkg/blank.py",
       "line": 1,
       "message": "Empty Python file (no code, or docstring-only)",
       "rule_id": "SKY-E002",
@@ -1212,7 +1212,7 @@
     },
     {
       "category": "DEAD_CODE",
-      "file": "pkg/orphan.ts",
+      "file": "/checkout/pkg/orphan.ts",
       "line": 1,
       "message": "Unused TypeScript/JavaScript file (not imported by any other file)",
       "rule_id": "SKY-E003",
@@ -1289,7 +1289,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "full_name": "pkg.mod.orphan",
       "line": 7,
       "name": "orphan",
@@ -1366,7 +1366,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "full_name": "pkg.mod.Greeter.farewell",
       "line": 24,
       "name": "Greeter.farewell",
@@ -1380,7 +1380,7 @@
       "basename": "mod.py",
       "confidence": 100,
       "dead_code_disposition": "reported",
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "full_name": "os",
       "line": 1,
       "name": "os",
@@ -1394,7 +1394,7 @@
       "basename": "mod.py",
       "confidence": 100,
       "dead_code_disposition": "reported",
-      "file": "pkg/mod.py",
+      "file": "/checkout/pkg/mod.py",
       "full_name": "pkg.mod.orphan.flag",
       "line": 7,
       "name": "flag",
@@ -1470,7 +1470,7 @@
         "no_entrypoint",
         "confidence_ge_threshold"
       ],
-      "file": "pkg/consts.py",
+      "file": "/checkout/pkg/consts.py",
       "full_name": "pkg.consts.LEGACY_LIMIT",
       "line": 5,
       "name": "LEGACY_LIMIT",

--- a/tests/fixtures/skylos_output.json
+++ b/tests/fixtures/skylos_output.json
@@ -2,27 +2,1196 @@
   "analysis_errors": [],
   "analysis_summary": {
     "analysis_error_count": 0,
-    "excluded_folders": [],
-    "languages": [
-      "python"
+    "by_directory": [
+      {
+        "dead_code": 8,
+        "files": 5,
+        "path": "pkg",
+        "rules": {
+          "SKY-E002": 1,
+          "SKY-E003": 1,
+          "unused-classes": 1,
+          "unused-functions": 2,
+          "unused-imports": 1,
+          "unused-parameters": 1,
+          "unused-variables": 1
+        },
+        "severities": {
+          "LOW": 8
+        },
+        "total": 8
+      }
     ],
-    "total_files": 3
+    "comparison_scope": {
+      "changed_files_only": false,
+      "complete_repository": false,
+      "excluded_folders": [
+        ".coverage",
+        "venv",
+        "vendor",
+        ".hg",
+        ".tox",
+        "htmlcov",
+        ".git",
+        "__pycache__",
+        ".svn",
+        "*.egg-info",
+        ".pytest_cache",
+        ".mypy_cache",
+        "node_modules",
+        ".idea",
+        ".next",
+        ".nuxt",
+        ".venv",
+        ".turbo",
+        "build",
+        ".vscode",
+        "dist"
+      ],
+      "kind": "repository_root_with_exclusions",
+      "repository_root": ".",
+      "scan_path": "."
+    },
+    "dead_code_evidence": {
+      "candidate_decisions": {
+        "abstained": 0,
+        "reported": 6,
+        "rescued": 0
+      },
+      "classification_policy": "dead-code-evidence-v3",
+      "classifications": {
+        "alive": 7,
+        "likely_dead": 4
+      },
+      "symbol_count": 11
+    },
+    "dead_code_liveness": {
+      "rescued": [],
+      "rescued_count": 0
+    },
+    "excluded_folders": [
+      ".coverage",
+      "venv",
+      "vendor",
+      ".hg",
+      ".tox",
+      "htmlcov",
+      ".git",
+      "__pycache__",
+      ".svn",
+      "*.egg-info",
+      ".pytest_cache",
+      ".mypy_cache",
+      "node_modules",
+      ".idea",
+      ".next",
+      ".nuxt",
+      ".venv",
+      ".turbo",
+      "build",
+      ".vscode",
+      "dist"
+    ],
+    "grade_categories": [
+      "dead_code"
+    ],
+    "grep_verify": {
+      "enabled": true,
+      "project_cache_enabled": true,
+      "rescued_count": 1
+    },
+    "languages": {
+      "Python": 5,
+      "TypeScript": 1
+    },
+    "monorepo_detected": false,
+    "total_files": 6,
+    "total_loc": 32,
+    "unused_files_count": 2,
+    "workspace_count": 0,
+    "workspace_diagnostic_count": 0,
+    "workspace_total_packages": 0
   },
   "dead_code_abstentions": [],
-  "dead_code_evidence": [],
+  "dead_code_evidence": {
+    "classification_policy": "dead-code-evidence-v3",
+    "symbols": [
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Static references found",
+          "reason_tags": [
+            "static_reference"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 2
+            },
+            "kind": "static_reference",
+            "reason": "referenced by static analysis",
+            "role": "supports_live",
+            "source": "analyzer"
+          }
+        ],
+        "file": "pkg/consts.py",
+        "kind": "variable",
+        "line": 3,
+        "qualified_name": "pkg.consts.ACTIVE_LIMIT"
+      },
+      {
+        "classification": "likely_dead",
+        "decision": {
+          "classification": "likely_dead",
+          "confidence": 60,
+          "dead_evidence_count": 4,
+          "live_evidence_count": 0,
+          "primary_reason": "No static references; Not exported; No entrypoint evidence",
+          "reason_tags": [
+            "no_refs",
+            "not_exported",
+            "no_entrypoint",
+            "confidence_ge_threshold"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 0
+            },
+            "kind": "no_static_references",
+            "reason": "no static references were found",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "not_exported",
+            "reason": "symbol is not exported as public API",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "no_entrypoint",
+            "reason": "no package, framework, test, or root entrypoint evidence",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 0.6,
+            "details": {
+              "confidence": 60,
+              "threshold": 60
+            },
+            "kind": "confidence_gate",
+            "reason": "confidence meets the configured reporting threshold",
+            "role": "supports_dead",
+            "source": "confidence"
+          }
+        ],
+        "file": "pkg/consts.py",
+        "kind": "variable",
+        "line": 5,
+        "qualified_name": "pkg.consts.LEGACY_LIMIT"
+      },
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Called during module import",
+          "reason_tags": [
+            "top_level_execution"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "top_level_execution",
+            "reason": "called during module top-level execution",
+            "role": "supports_live",
+            "source": "python_ast"
+          }
+        ],
+        "file": "pkg/mod.py",
+        "kind": "class",
+        "line": 17,
+        "qualified_name": "pkg.mod.Greeter"
+      },
+      {
+        "classification": "likely_dead",
+        "decision": {
+          "classification": "likely_dead",
+          "confidence": 100,
+          "dead_evidence_count": 4,
+          "live_evidence_count": 0,
+          "primary_reason": "No static references; Not exported; No entrypoint evidence",
+          "reason_tags": [
+            "no_refs",
+            "not_exported",
+            "no_entrypoint",
+            "confidence_ge_threshold"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 0
+            },
+            "kind": "no_static_references",
+            "reason": "no static references were found",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "not_exported",
+            "reason": "symbol is not exported as public API",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "no_entrypoint",
+            "reason": "no package, framework, test, or root entrypoint evidence",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {
+              "confidence": 100,
+              "threshold": 60
+            },
+            "kind": "confidence_gate",
+            "reason": "confidence meets the configured reporting threshold",
+            "role": "supports_dead",
+            "source": "confidence"
+          }
+        ],
+        "file": "pkg/mod.py",
+        "kind": "method",
+        "line": 24,
+        "qualified_name": "pkg.mod.Greeter.farewell"
+      },
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Static references found",
+          "reason_tags": [
+            "static_reference"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 0.3,
+            "details": {
+              "bucket": "same_pkg_attr"
+            },
+            "kind": "attribute_name_match",
+            "reason": "unverified same_pkg_attr match",
+            "role": "context",
+            "source": "attribute_reference"
+          },
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 1
+            },
+            "kind": "static_reference",
+            "reason": "referenced by static analysis",
+            "role": "supports_live",
+            "source": "analyzer"
+          }
+        ],
+        "file": "pkg/mod.py",
+        "kind": "method",
+        "line": 20,
+        "qualified_name": "pkg.mod.Greeter.greet"
+      },
+      {
+        "classification": "likely_dead",
+        "decision": {
+          "classification": "likely_dead",
+          "confidence": 100,
+          "dead_evidence_count": 4,
+          "live_evidence_count": 0,
+          "primary_reason": "No static references; Not exported; No entrypoint evidence",
+          "reason_tags": [
+            "no_refs",
+            "not_exported",
+            "no_entrypoint",
+            "confidence_ge_threshold"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 0
+            },
+            "kind": "no_static_references",
+            "reason": "no static references were found",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "not_exported",
+            "reason": "symbol is not exported as public API",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "no_entrypoint",
+            "reason": "no package, framework, test, or root entrypoint evidence",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {
+              "confidence": 100,
+              "threshold": 60
+            },
+            "kind": "confidence_gate",
+            "reason": "confidence meets the configured reporting threshold",
+            "role": "supports_dead",
+            "source": "confidence"
+          }
+        ],
+        "file": "pkg/mod.py",
+        "kind": "function",
+        "line": 7,
+        "qualified_name": "pkg.mod.orphan"
+      },
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Static references found",
+          "reason_tags": [
+            "static_reference"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 2
+            },
+            "kind": "static_reference",
+            "reason": "referenced by static analysis",
+            "role": "supports_live",
+            "source": "analyzer"
+          }
+        ],
+        "file": "pkg/mod.py",
+        "kind": "function",
+        "line": 12,
+        "qualified_name": "pkg.mod.used"
+      },
+      {
+        "classification": "likely_dead",
+        "decision": {
+          "classification": "likely_dead",
+          "confidence": 100,
+          "dead_evidence_count": 4,
+          "live_evidence_count": 0,
+          "primary_reason": "No static references; Not exported; No entrypoint evidence",
+          "reason_tags": [
+            "no_refs",
+            "not_exported",
+            "no_entrypoint",
+            "confidence_ge_threshold"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 0
+            },
+            "kind": "no_static_references",
+            "reason": "no static references were found",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "not_exported",
+            "reason": "symbol is not exported as public API",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "no_entrypoint",
+            "reason": "no package, framework, test, or root entrypoint evidence",
+            "role": "supports_dead",
+            "source": "analyzer"
+          },
+          {
+            "confidence": 1.0,
+            "details": {
+              "confidence": 100,
+              "threshold": 60
+            },
+            "kind": "confidence_gate",
+            "reason": "confidence meets the configured reporting threshold",
+            "role": "supports_dead",
+            "source": "confidence"
+          }
+        ],
+        "file": "pkg/shapes.py",
+        "kind": "class",
+        "line": 12,
+        "qualified_name": "pkg.shapes.Hexagon"
+      },
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Grep verification found usage",
+          "reason_tags": [
+            "grep_rescue"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 0.3,
+            "details": {
+              "bucket": "same_pkg_attr"
+            },
+            "kind": "attribute_name_match",
+            "reason": "unverified same_pkg_attr match",
+            "role": "context",
+            "source": "attribute_reference"
+          },
+          {
+            "confidence": 1.0,
+            "details": {},
+            "kind": "grep_rescue",
+            "reason": "grep verification found a usage",
+            "role": "supports_live",
+            "source": "grep_verify"
+          }
+        ],
+        "file": "pkg/shapes.py",
+        "kind": "method",
+        "line": 15,
+        "qualified_name": "pkg.shapes.Hexagon.area"
+      },
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Static references found",
+          "reason_tags": [
+            "static_reference"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 2
+            },
+            "kind": "static_reference",
+            "reason": "referenced by static analysis",
+            "role": "supports_live",
+            "source": "analyzer"
+          }
+        ],
+        "file": "pkg/shapes.py",
+        "kind": "class",
+        "line": 4,
+        "qualified_name": "pkg.shapes.Square"
+      },
+      {
+        "classification": "alive",
+        "decision": {
+          "classification": "alive",
+          "confidence": 100,
+          "dead_evidence_count": 0,
+          "live_evidence_count": 1,
+          "primary_reason": "Static references found",
+          "reason_tags": [
+            "static_reference"
+          ],
+          "threshold": 60,
+          "uncertainty_count": 0
+        },
+        "evidence": [
+          {
+            "confidence": 0.3,
+            "details": {
+              "bucket": "same_pkg_attr"
+            },
+            "kind": "attribute_name_match",
+            "reason": "unverified same_pkg_attr match",
+            "role": "context",
+            "source": "attribute_reference"
+          },
+          {
+            "confidence": 1.0,
+            "details": {
+              "references": 1
+            },
+            "kind": "static_reference",
+            "reason": "referenced by static analysis",
+            "role": "supports_live",
+            "source": "analyzer"
+          }
+        ],
+        "file": "pkg/shapes.py",
+        "kind": "method",
+        "line": 7,
+        "qualified_name": "pkg.shapes.Square.area"
+      }
+    ]
+  },
   "dead_code_rescues": [],
   "definitions": {
+    "pkg.mod.Greeter": {
+      "called_by": [],
+      "calls": [],
+      "complexity": 1,
+      "dead": false,
+      "dead_code_classification": "alive",
+      "dead_code_decision": {
+        "classification": "alive",
+        "confidence": 100,
+        "dead_evidence_count": 0,
+        "live_evidence_count": 1,
+        "primary_reason": "Called during module import",
+        "reason_tags": [
+          "top_level_execution"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "top_level_execution",
+          "reason": "called during module top-level execution",
+          "role": "supports_live",
+          "source": "python_ast"
+        }
+      ],
+      "dead_code_reason": "Called during module import",
+      "dead_code_reason_tags": [
+        "top_level_execution"
+      ],
+      "file": "pkg/mod.py",
+      "line": 17,
+      "loc": 10,
+      "name": "pkg.mod.Greeter",
+      "type": "class"
+    },
+    "pkg.mod.Greeter.farewell": {
+      "called_by": [],
+      "calls": [
+        "pkg.mod.used"
+      ],
+      "complexity": 1,
+      "dead": true,
+      "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 100,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "confidence": 100,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
+      "file": "pkg/mod.py",
+      "line": 24,
+      "loc": 3,
+      "name": "pkg.mod.Greeter.farewell",
+      "type": "method"
+    },
+    "pkg.mod.Greeter.greet": {
+      "called_by": [],
+      "calls": [
+        "pkg.mod.used"
+      ],
+      "complexity": 1,
+      "dead": false,
+      "dead_code_classification": "alive",
+      "dead_code_decision": {
+        "classification": "alive",
+        "confidence": 100,
+        "dead_evidence_count": 0,
+        "live_evidence_count": 1,
+        "primary_reason": "Static references found",
+        "reason_tags": [
+          "static_reference"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 0.3,
+          "details": {
+            "bucket": "same_pkg_attr"
+          },
+          "kind": "attribute_name_match",
+          "reason": "unverified same_pkg_attr match",
+          "role": "context",
+          "source": "attribute_reference"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 1
+          },
+          "kind": "static_reference",
+          "reason": "referenced by static analysis",
+          "role": "supports_live",
+          "source": "analyzer"
+        }
+      ],
+      "dead_code_reason": "Static references found",
+      "dead_code_reason_tags": [
+        "static_reference"
+      ],
+      "file": "pkg/mod.py",
+      "line": 20,
+      "loc": 3,
+      "name": "pkg.mod.Greeter.greet",
+      "type": "method"
+    },
+    "pkg.mod.orphan": {
+      "called_by": [],
+      "calls": [
+        "pkg.consts.ACTIVE_LIMIT"
+      ],
+      "complexity": 1,
+      "dead": true,
+      "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 100,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "confidence": 100,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
+      "file": "pkg/mod.py",
+      "line": 7,
+      "loc": 3,
+      "name": "pkg.mod.orphan",
+      "type": "function"
+    },
     "pkg.mod.used": {
-      "references": 4
+      "called_by": [
+        "pkg.mod.Greeter.farewell",
+        "pkg.mod.Greeter.greet"
+      ],
+      "calls": [
+        "pkg.shapes.Square",
+        "pkg.shapes.Square.area"
+      ],
+      "complexity": 1,
+      "dead": false,
+      "dead_code_classification": "alive",
+      "dead_code_decision": {
+        "classification": "alive",
+        "confidence": 100,
+        "dead_evidence_count": 0,
+        "live_evidence_count": 1,
+        "primary_reason": "Static references found",
+        "reason_tags": [
+          "static_reference"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 2
+          },
+          "kind": "static_reference",
+          "reason": "referenced by static analysis",
+          "role": "supports_live",
+          "source": "analyzer"
+        }
+      ],
+      "dead_code_reason": "Static references found",
+      "dead_code_reason_tags": [
+        "static_reference"
+      ],
+      "file": "pkg/mod.py",
+      "line": 12,
+      "loc": 3,
+      "name": "pkg.mod.used",
+      "type": "function"
+    },
+    "pkg.shapes.Hexagon": {
+      "called_by": [],
+      "calls": [],
+      "complexity": 1,
+      "dead": true,
+      "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 100,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "confidence": 100,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
+      "file": "pkg/shapes.py",
+      "line": 12,
+      "loc": 6,
+      "name": "pkg.shapes.Hexagon",
+      "type": "class"
+    },
+    "pkg.shapes.Hexagon.area": {
+      "called_by": [],
+      "calls": [],
+      "complexity": 1,
+      "dead": false,
+      "dead_code_classification": "alive",
+      "dead_code_decision": {
+        "classification": "alive",
+        "confidence": 100,
+        "dead_evidence_count": 0,
+        "live_evidence_count": 1,
+        "primary_reason": "Grep verification found usage",
+        "reason_tags": [
+          "grep_rescue"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 0.3,
+          "details": {
+            "bucket": "same_pkg_attr"
+          },
+          "kind": "attribute_name_match",
+          "reason": "unverified same_pkg_attr match",
+          "role": "context",
+          "source": "attribute_reference"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "grep_rescue",
+          "reason": "grep verification found a usage",
+          "role": "supports_live",
+          "source": "grep_verify"
+        }
+      ],
+      "dead_code_reason": "Grep verification found usage",
+      "dead_code_reason_tags": [
+        "grep_rescue"
+      ],
+      "file": "pkg/shapes.py",
+      "line": 15,
+      "loc": 3,
+      "name": "pkg.shapes.Hexagon.area",
+      "type": "method"
+    },
+    "pkg.shapes.Square": {
+      "called_by": [],
+      "calls": [],
+      "complexity": 1,
+      "dead": false,
+      "dead_code_classification": "alive",
+      "dead_code_decision": {
+        "classification": "alive",
+        "confidence": 100,
+        "dead_evidence_count": 0,
+        "live_evidence_count": 1,
+        "primary_reason": "Static references found",
+        "reason_tags": [
+          "static_reference"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 2
+          },
+          "kind": "static_reference",
+          "reason": "referenced by static analysis",
+          "role": "supports_live",
+          "source": "analyzer"
+        }
+      ],
+      "dead_code_reason": "Static references found",
+      "dead_code_reason_tags": [
+        "static_reference"
+      ],
+      "file": "pkg/shapes.py",
+      "line": 4,
+      "loc": 6,
+      "name": "pkg.shapes.Square",
+      "type": "class"
+    },
+    "pkg.shapes.Square.area": {
+      "called_by": [],
+      "calls": [],
+      "complexity": 1,
+      "dead": false,
+      "dead_code_classification": "alive",
+      "dead_code_decision": {
+        "classification": "alive",
+        "confidence": 100,
+        "dead_evidence_count": 0,
+        "live_evidence_count": 1,
+        "primary_reason": "Static references found",
+        "reason_tags": [
+          "static_reference"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
+      "dead_code_evidence": [
+        {
+          "confidence": 0.3,
+          "details": {
+            "bucket": "same_pkg_attr"
+          },
+          "kind": "attribute_name_match",
+          "reason": "unverified same_pkg_attr match",
+          "role": "context",
+          "source": "attribute_reference"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 1
+          },
+          "kind": "static_reference",
+          "reason": "referenced by static analysis",
+          "role": "supports_live",
+          "source": "analyzer"
+        }
+      ],
+      "dead_code_reason": "Static references found",
+      "dead_code_reason_tags": [
+        "static_reference"
+      ],
+      "file": "pkg/shapes.py",
+      "line": 7,
+      "loc": 3,
+      "name": "pkg.shapes.Square.area",
+      "type": "method"
     }
+  },
+  "grade": {
+    "categories": {
+      "dead_code": {
+        "base_weight": 0.15,
+        "key_issue": "6 dead symbols (187.5/1K LOC)",
+        "letter": "F",
+        "score": 0,
+        "weight": 1.0
+      }
+    },
+    "overall": {
+      "letter": "F",
+      "score": 0
+    },
+    "scanned_categories": [
+      "dead_code"
+    ],
+    "total_loc": 32
   },
   "suppressed": [],
   "unused_classes": [
     {
       "basename": "shapes.py",
-      "confidence": 86,
+      "confidence": 100,
       "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 100,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
       "dead_code_disposition": "reported",
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "confidence": 100,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
       "file": "pkg/shapes.py",
       "full_name": "pkg.shapes.Hexagon",
       "line": 12,
@@ -53,12 +1222,76 @@
   "unused_functions": [
     {
       "basename": "mod.py",
+      "calls": [
+        "pkg.consts.ACTIVE_LIMIT"
+      ],
       "confidence": 100,
-      "dead_code_classification": "dead",
+      "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 100,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
       "dead_code_disposition": "reported",
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "confidence": 100,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
       "file": "pkg/mod.py",
       "full_name": "pkg.mod.orphan",
-      "line": 4,
+      "line": 7,
       "name": "orphan",
       "references": 0,
       "simple_name": "orphan",
@@ -66,14 +1299,76 @@
     },
     {
       "basename": "mod.py",
-      "calls": [],
-      "confidence": 74,
+      "calls": [
+        "pkg.mod.used"
+      ],
+      "confidence": 100,
       "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 100,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
       "dead_code_disposition": "reported",
-      "decorators": [],
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {
+            "confidence": 100,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
       "file": "pkg/mod.py",
       "full_name": "pkg.mod.Greeter.farewell",
-      "line": 21,
+      "line": 24,
       "name": "Greeter.farewell",
       "references": 0,
       "simple_name": "farewell",
@@ -83,12 +1378,10 @@
   "unused_imports": [
     {
       "basename": "mod.py",
-      "conditional_import": false,
-      "confidence": 95,
-      "dead_code_classification": "dead",
+      "confidence": 100,
       "dead_code_disposition": "reported",
       "file": "pkg/mod.py",
-      "full_name": "pkg.mod.os",
+      "full_name": "os",
       "line": 1,
       "name": "os",
       "references": 0,
@@ -99,12 +1392,11 @@
   "unused_parameters": [
     {
       "basename": "mod.py",
-      "confidence": 61,
-      "dead_code_classification": "uncertain_reported",
+      "confidence": 100,
       "dead_code_disposition": "reported",
       "file": "pkg/mod.py",
       "full_name": "pkg.mod.orphan.flag",
-      "line": 4,
+      "line": 7,
       "name": "flag",
       "references": 0,
       "simple_name": "flag",
@@ -114,17 +1406,89 @@
   "unused_variables": [
     {
       "basename": "consts.py",
-      "confidence": 68,
+      "confidence": 60,
       "dead_code_classification": "likely_dead",
+      "dead_code_decision": {
+        "classification": "likely_dead",
+        "confidence": 60,
+        "dead_evidence_count": 4,
+        "live_evidence_count": 0,
+        "primary_reason": "No static references; Not exported; No entrypoint evidence",
+        "reason_tags": [
+          "no_refs",
+          "not_exported",
+          "no_entrypoint",
+          "confidence_ge_threshold"
+        ],
+        "threshold": 60,
+        "uncertainty_count": 0
+      },
       "dead_code_disposition": "reported",
+      "dead_code_evidence": [
+        {
+          "confidence": 1.0,
+          "details": {
+            "references": 0
+          },
+          "kind": "no_static_references",
+          "reason": "no static references were found",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "not_exported",
+          "reason": "symbol is not exported as public API",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 1.0,
+          "details": {},
+          "kind": "no_entrypoint",
+          "reason": "no package, framework, test, or root entrypoint evidence",
+          "role": "supports_dead",
+          "source": "analyzer"
+        },
+        {
+          "confidence": 0.6,
+          "details": {
+            "confidence": 60,
+            "threshold": 60
+          },
+          "kind": "confidence_gate",
+          "reason": "confidence meets the configured reporting threshold",
+          "role": "supports_dead",
+          "source": "confidence"
+        }
+      ],
+      "dead_code_reason": "No static references; Not exported; No entrypoint evidence",
+      "dead_code_reason_tags": [
+        "no_refs",
+        "not_exported",
+        "no_entrypoint",
+        "confidence_ge_threshold"
+      ],
       "file": "pkg/consts.py",
       "full_name": "pkg.consts.LEGACY_LIMIT",
-      "line": 7,
+      "line": 5,
       "name": "LEGACY_LIMIT",
       "references": 0,
       "simple_name": "LEGACY_LIMIT",
-      "type": "constant"
+      "type": "variable"
     }
   ],
-  "whitelisted": []
+  "whitelisted": [],
+  "workspaces": {
+    "declared_patterns": [],
+    "diagnostic_count": 0,
+    "diagnostics": [],
+    "is_monorepo": false,
+    "package_count": 0,
+    "packages": [],
+    "root_package": null,
+    "total_packages": 0,
+    "tsconfig_references": []
+  }
 }

--- a/tests/test_report_source.py
+++ b/tests/test_report_source.py
@@ -149,6 +149,66 @@ def test_collect_out_of_range_line_warns_per_location(tmp_path: Path) -> None:
     assert warning == 'pkg/mod.py:L99: reported line 99 is beyond the end of the file (20 line(s))'
 
 
+def test_collect_file_level_finding_on_zero_line_file_is_source_less(tmp_path: Path) -> None:
+    # Reporting §3.3: a file-level finding on a file with zero source lines
+    # (e.g. skylos SKY-E002) reports the emptiness itself. It is
+    # intentionally source-less, so it neither fabricates an excerpt nor
+    # spends the warning budget that exists for genuine source anomalies.
+    checkout = write_checkout(tmp_path)
+    atomic_write_text(checkout / 'pkg' / 'blank.py', '')
+    empty = diff(
+        DiffClass.NEW,
+        None,
+        path='pkg/blank.py',
+        kind='file',
+        head=occurrence(1, 'Empty Python file (no code, or docstring-only)', rule_id='SKY-E002'),
+    )
+    missing = diff(DiffClass.NEW, 'a', path='pkg/gone.py', head=occurrence(1, 'm'))
+    (enriched_empty, enriched_missing), warnings = collect_source_evidence(
+        (empty, missing), checkout=checkout, excerpt_lines=2
+    )
+    assert enriched_empty.head_occurrence is not None
+    assert enriched_empty.head_occurrence.source_excerpt is None
+    # The budget still surfaces the unrelated anomaly.
+    (warning,) = warnings
+    assert warning.startswith('pkg/gone.py: ')
+    assert enriched_missing.head_occurrence is not None
+    assert enriched_missing.head_occurrence.source_excerpt is None
+
+
+def test_collect_file_level_finding_on_nonempty_file_gets_evidence(tmp_path: Path) -> None:
+    # A docstring-only file also triggers SKY-E002 but has source lines:
+    # ordinary excerpt extraction applies.
+    checkout = write_checkout(tmp_path)
+    atomic_write_text(checkout / 'pkg' / 'doc.py', '"""Docstring only."""\n')
+    entry = diff(
+        DiffClass.NEW,
+        None,
+        path='pkg/doc.py',
+        kind='file',
+        head=occurrence(1, 'Empty Python file (no code, or docstring-only)', rule_id='SKY-E002'),
+    )
+    (enriched,), warnings = collect_source_evidence((entry,), checkout=checkout, excerpt_lines=2)
+    assert warnings == ()
+    assert enriched.head_occurrence is not None
+    assert enriched.head_occurrence.source_excerpt == SourceExcerpt(
+        start_line=1, lines=('"""Docstring only."""',), omitted_lines=0
+    )
+
+
+def test_collect_symbol_finding_on_zero_line_file_still_warns(tmp_path: Path) -> None:
+    # The empty-file exemption is for file-level findings only: a symbol
+    # finding pointing into a zero-line file remains a source anomaly.
+    checkout = write_checkout(tmp_path)
+    atomic_write_text(checkout / 'pkg' / 'blank.py', '')
+    entry = diff(DiffClass.NEW, 'a', path='pkg/blank.py', head=occurrence(1, 'm'))
+    (enriched,), warnings = collect_source_evidence((entry,), checkout=checkout, excerpt_lines=2)
+    assert enriched.head_occurrence is not None
+    assert enriched.head_occurrence.source_excerpt is None
+    (warning,) = warnings
+    assert warning == 'pkg/blank.py:L1: reported line 1 is beyond the end of the file (0 line(s))'
+
+
 def test_collect_rejects_symlinks_special_and_undecodable_files(tmp_path: Path) -> None:
     checkout = write_checkout(tmp_path)
     (checkout / 'pkg' / 'link.py').symlink_to(checkout / 'pkg' / 'mod.py')

--- a/tests/test_report_source.py
+++ b/tests/test_report_source.py
@@ -196,6 +196,41 @@ def test_collect_file_level_finding_on_nonempty_file_gets_evidence(tmp_path: Pat
     )
 
 
+def test_collect_symbol_bearing_file_kind_on_zero_line_file_still_warns(tmp_path: Path) -> None:
+    # Adversarial detector output can script `type: "file"` on a
+    # symbol-bucket entry. A symbol-bearing occurrence is not the
+    # normalized unused-file shape, so the empty-file exemption does not
+    # apply and the anomaly still warns.
+    checkout = write_checkout(tmp_path)
+    atomic_write_text(checkout / 'pkg' / 'blank.py', '')
+    entry = diff(DiffClass.NEW, 'rogue', path='pkg/blank.py', kind='file', head=occurrence(1, 'm'))
+    (enriched,), warnings = collect_source_evidence((entry,), checkout=checkout, excerpt_lines=2)
+    assert enriched.head_occurrence is not None
+    assert enriched.head_occurrence.source_excerpt is None
+    (warning,) = warnings
+    assert warning == 'pkg/blank.py:L1: reported line 1 is beyond the end of the file (0 line(s))'
+
+
+def test_collect_file_finding_past_line_one_on_zero_line_file_still_warns(tmp_path: Path) -> None:
+    # A file-level finding claiming source at line 40 of a zero-byte file
+    # is not reporting the emptiness: the claimed location is anomalous and
+    # must keep its warning.
+    checkout = write_checkout(tmp_path)
+    atomic_write_text(checkout / 'pkg' / 'blank.py', '')
+    entry = diff(
+        DiffClass.NEW,
+        None,
+        path='pkg/blank.py',
+        kind='file',
+        head=occurrence(40, 'Empty Python file (no code, or docstring-only)', rule_id='SKY-E002'),
+    )
+    (enriched,), warnings = collect_source_evidence((entry,), checkout=checkout, excerpt_lines=2)
+    assert enriched.head_occurrence is not None
+    assert enriched.head_occurrence.source_excerpt is None
+    (warning,) = warnings
+    assert warning == 'pkg/blank.py:L40: reported line 40 is beyond the end of the file (0 line(s))'
+
+
 def test_collect_symbol_finding_on_zero_line_file_still_warns(tmp_path: Path) -> None:
     # The empty-file exemption is for file-level findings only: a symbol
     # finding pointing into a zero-line file remains a source anomaly.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -777,7 +777,6 @@ def test_fake_skylos_unused_file_end_to_end(tmp_path: Path) -> None:
                 path='pkg/empty.py',
                 line=1,
                 symbol='pkg/empty.py',
-                kind='file',
                 bucket='unused_files',
                 rule_id='SKY-E002',
                 severity='LOW',

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -758,6 +758,44 @@ def test_fake_skylos_rule_change_splits_into_dropped_plus_new(tmp_path: Path, co
     assert report.rollups == project_report.rollups
 
 
+def test_fake_skylos_unused_file_end_to_end(tmp_path: Path, corpus_project: CorpusProject) -> None:
+    head_cmd = write_fake_detector_script(
+        tmp_path / 'sky-head.json',
+        [
+            FakeFinding(
+                path='pkg/mod.py',
+                line=1,
+                symbol='pkg/mod.py',
+                kind='file',
+                bucket='unused_files',
+                rule_id='SKY-E002',
+                severity='LOW',
+                message='Empty Python file (no code, or docstring-only)',
+            )
+        ],
+        output_format='skylos',
+    )
+    base_cmd = write_fake_detector_script(tmp_path / 'sky-base.json', [], output_format='skylos')
+
+    report = skylos_runner(tmp_path).run_escape_hatch(
+        [corpus_project],
+        base_cmd=base_cmd,
+        head_cmd=head_cmd,
+    )
+
+    (project_report,) = report.projects
+    assert project_report.errors == ()
+    assert project_report.totals == DiffTotals(new=1)
+    (diff,) = project_report.diffs
+    assert diff.path == 'pkg/mod.py'
+    assert diff.symbol is None
+    assert diff.kind == 'file'
+    assert diff.head_occurrence is not None
+    assert diff.head_occurrence.message == 'Empty Python file (no code, or docstring-only)'
+    assert diff.head_occurrence.rule_id == 'SKY-E002'
+    assert diff.head_occurrence.severity == 'LOW'
+
+
 def test_fake_skylos_danger_severity_change_end_to_end(tmp_path: Path, corpus_project: CorpusProject) -> None:
     # Reporting acceptance 32, end to end through the skylos adapter's
     # danger ingestion: a severity change pairs as one `changed` diff, and

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -758,14 +758,25 @@ def test_fake_skylos_rule_change_splits_into_dropped_plus_new(tmp_path: Path, co
     assert report.rollups == project_report.rollups
 
 
-def test_fake_skylos_unused_file_end_to_end(tmp_path: Path, corpus_project: CorpusProject) -> None:
+def test_fake_skylos_unused_file_end_to_end(tmp_path: Path) -> None:
+    # A realistic SKY-E002 target: the pinned corpus checkout contains an
+    # actually zero-byte file. The file-level finding flows through as one
+    # `new` diff that is intentionally source-less — no excerpt, and no
+    # source warning spent on the expected emptiness (reporting §3.3).
+    origin = create_fake_project(
+        tmp_path / 'origin',
+        files={'pkg/mod.py': 'used = 1\n', 'pkg/empty.py': ''},
+        init_git=True,
+    )
+    assert origin.head_sha is not None
+    project = CorpusProject(name='fakeproj', repo=origin.url, pin=origin.head_sha)
     head_cmd = write_fake_detector_script(
         tmp_path / 'sky-head.json',
         [
             FakeFinding(
-                path='pkg/mod.py',
+                path='pkg/empty.py',
                 line=1,
-                symbol='pkg/mod.py',
+                symbol='pkg/empty.py',
                 kind='file',
                 bucket='unused_files',
                 rule_id='SKY-E002',
@@ -778,22 +789,24 @@ def test_fake_skylos_unused_file_end_to_end(tmp_path: Path, corpus_project: Corp
     base_cmd = write_fake_detector_script(tmp_path / 'sky-base.json', [], output_format='skylos')
 
     report = skylos_runner(tmp_path).run_escape_hatch(
-        [corpus_project],
+        [project],
         base_cmd=base_cmd,
         head_cmd=head_cmd,
     )
 
     (project_report,) = report.projects
     assert project_report.errors == ()
+    assert project_report.source_warnings == ()
     assert project_report.totals == DiffTotals(new=1)
     (diff,) = project_report.diffs
-    assert diff.path == 'pkg/mod.py'
+    assert diff.path == 'pkg/empty.py'
     assert diff.symbol is None
     assert diff.kind == 'file'
     assert diff.head_occurrence is not None
     assert diff.head_occurrence.message == 'Empty Python file (no code, or docstring-only)'
     assert diff.head_occurrence.rule_id == 'SKY-E002'
     assert diff.head_occurrence.severity == 'LOW'
+    assert diff.head_occurrence.source_excerpt is None
 
 
 def test_fake_skylos_danger_severity_change_end_to_end(tmp_path: Path, corpus_project: CorpusProject) -> None:

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -3,6 +3,7 @@
 """Tests for the shipped fake detector and fake project factory (contract §15)."""
 
 import json
+import re
 import stat
 import time
 from pathlib import Path
@@ -258,7 +259,6 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
                 path='orphan.ts',
                 line=3,
                 symbol='orphan.ts',
-                kind='file',
                 bucket='unused_files',
                 rule_id='SKY-E003',
                 severity='LOW',
@@ -268,15 +268,8 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
                 path='empty.py',
                 line=1,
                 symbol='empty.py',
-                kind='file',
                 bucket='unused_files',
-            ),
-            FakeFinding(
-                path='dead.ts',
-                line=1,
-                symbol='dead.ts',
-                kind='file',
-                bucket='unused_files',
+                rule_id='SKY-E002',
             ),
         ],
         output_format='skylos',
@@ -291,7 +284,7 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
     (variable_entry,) = document['unused_variables']
     assert 'rule_id' not in variable_entry
     assert variable_entry['name'] == 'y'
-    unused_file_entry, defaulted_python_entry, defaulted_typescript_entry = document['unused_files']
+    unused_file_entry, defaulted_entry = document['unused_files']
     assert unused_file_entry == {
         'rule_id': 'SKY-E003',
         'message': 'Unused TypeScript/JavaScript file',
@@ -299,29 +292,27 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
         'line': 3,
         'severity': 'LOW',
     }
-    # An unscripted rule ID is inferred from the path suffix, mirroring how
-    # real skylos assigns the unused-file rules: the adapter rejects a
-    # rule-less entry, so the fake never emits one.
-    assert defaulted_python_entry == {
+    # Only the message defaults; the rule ID is always scripted, and the
+    # severity every supported skylos revision stamps on an unused-file
+    # entry is emitted rather than omitted.
+    assert defaulted_entry == {
         'rule_id': 'SKY-E002',
         'message': "Unused file 'empty.py'",
         'file': 'empty.py',
         'line': 1,
-    }
-    assert defaulted_typescript_entry == {
-        'rule_id': 'SKY-E003',
-        'message': "Unused file 'dead.ts'",
-        'file': 'dead.ts',
-        'line': 1,
+        'severity': 'LOW',
     }
 
 
-@pytest.mark.parametrize('suffix', ['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs'])
-def test_fake_skylos_infers_e003_for_every_typescript_javascript_suffix(suffix: str) -> None:
-    """Infer the real Skylos unused-file rule for every TS/JS suffix."""
-    path = f'dead{suffix}'
-    entry = FakeFinding(path=path, line=1, symbol=path, kind='file', bucket='unused_files').skylos_entry()
-    assert entry['rule_id'] == 'SKY-E003'
+def test_fake_skylos_unused_file_requires_an_explicit_rule_id() -> None:
+    """Reject a scripted unused-file finding carrying no rule ID."""
+    # The bucket is multi-rule and its rules turn on conditions the fake
+    # cannot observe, so the rule is scripted rather than guessed from the
+    # path; the adapter rejects a rule-less entry in any case.
+    finding = FakeFinding(path='dead.ts', line=1, symbol='dead.ts', bucket='unused_files')
+    message = re.escape("unused_files finding for 'dead.ts' needs an explicit rule_id")
+    with pytest.raises(ValueError, match=message):
+        finding.skylos_entry()
 
 
 def test_main_skylos_format_clean_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -21,7 +21,7 @@ from liveness_primer.launcher import LauncherError, SyncLauncher, run_async, run
 from liveness_primer.testing import FakeFinding, create_fake_project, write_fake_detector_script
 from liveness_primer.testing.fake_detector import main
 from liveness_primer.testing.fake_project import DEFAULT_FILES, FakeProjectError
-from liveness_primer.tools.skylos import BUCKET_RULE_IDS
+from liveness_primer.tools.skylos import DEAD_CODE_KEYS
 
 
 def test_fake_finding_report_line_matches_vulture_format() -> None:
@@ -271,6 +271,13 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
                 kind='file',
                 bucket='unused_files',
             ),
+            FakeFinding(
+                path='dead.ts',
+                line=1,
+                symbol='dead.ts',
+                kind='file',
+                bucket='unused_files',
+            ),
         ],
         output_format='skylos',
     )
@@ -284,17 +291,27 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
     (variable_entry,) = document['unused_variables']
     assert 'rule_id' not in variable_entry
     assert variable_entry['name'] == 'y'
-    unused_file_entry, defaulted_unused_file_entry = document['unused_files']
+    unused_file_entry, defaulted_python_entry, defaulted_typescript_entry = document['unused_files']
     assert unused_file_entry == {
+        'rule_id': 'SKY-E003',
         'message': 'Unused TypeScript/JavaScript file',
         'file': 'orphan.ts',
         'line': 3,
-        'rule_id': 'SKY-E003',
         'severity': 'LOW',
     }
-    assert defaulted_unused_file_entry == {
+    # An unscripted rule ID is inferred from the path suffix, mirroring how
+    # real skylos assigns the unused-file rules: the adapter rejects a
+    # rule-less entry, so the fake never emits one.
+    assert defaulted_python_entry == {
+        'rule_id': 'SKY-E002',
         'message': "Unused file 'empty.py'",
         'file': 'empty.py',
+        'line': 1,
+    }
+    assert defaulted_typescript_entry == {
+        'rule_id': 'SKY-E003',
+        'message': "Unused file 'dead.ts'",
+        'file': 'dead.ts',
         'line': 1,
     }
 
@@ -302,7 +319,9 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
 def test_main_skylos_format_clean_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     command = write_fake_detector_script(tmp_path / 'script.json', [], output_format='skylos')
     assert main(command[3:]) == 0
-    assert json.loads(capsys.readouterr().out) == {key: [] for key in BUCKET_RULE_IDS}
+    # The clean document carries every always-ingested dead-code bucket —
+    # including the multi-rule `unused_files` — like a real skylos run.
+    assert json.loads(capsys.readouterr().out) == {key: [] for key in DEAD_CODE_KEYS}
 
 
 def test_main_emits_skylos_danger_diagnostics(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -254,6 +254,23 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
         [
             FakeFinding(path='a.py', line=1, symbol='x', kind='function', rule_id='SKY-U777'),
             FakeFinding(path='a.py', line=2, symbol='y', kind='variable', bucket='unused_variables'),
+            FakeFinding(
+                path='orphan.ts',
+                line=3,
+                symbol='orphan.ts',
+                kind='file',
+                bucket='unused_files',
+                rule_id='SKY-E003',
+                severity='LOW',
+                message='Unused TypeScript/JavaScript file',
+            ),
+            FakeFinding(
+                path='empty.py',
+                line=1,
+                symbol='empty.py',
+                kind='file',
+                bucket='unused_files',
+            ),
         ],
         output_format='skylos',
     )
@@ -267,6 +284,19 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
     (variable_entry,) = document['unused_variables']
     assert 'rule_id' not in variable_entry
     assert variable_entry['name'] == 'y'
+    unused_file_entry, defaulted_unused_file_entry = document['unused_files']
+    assert unused_file_entry == {
+        'message': 'Unused TypeScript/JavaScript file',
+        'file': 'orphan.ts',
+        'line': 3,
+        'rule_id': 'SKY-E003',
+        'severity': 'LOW',
+    }
+    assert defaulted_unused_file_entry == {
+        'message': "Unused file 'empty.py'",
+        'file': 'empty.py',
+        'line': 1,
+    }
 
 
 def test_main_skylos_format_clean_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -278,6 +278,13 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
                 kind='file',
                 bucket='unused_files',
             ),
+            FakeFinding(
+                path='dead.mjs',
+                line=1,
+                symbol='dead.mjs',
+                kind='file',
+                bucket='unused_files',
+            ),
         ],
         output_format='skylos',
     )
@@ -291,7 +298,9 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
     (variable_entry,) = document['unused_variables']
     assert 'rule_id' not in variable_entry
     assert variable_entry['name'] == 'y'
-    unused_file_entry, defaulted_python_entry, defaulted_typescript_entry = document['unused_files']
+    unused_file_entry, defaulted_python_entry, defaulted_typescript_entry, defaulted_module_entry = document[
+        'unused_files'
+    ]
     assert unused_file_entry == {
         'rule_id': 'SKY-E003',
         'message': 'Unused TypeScript/JavaScript file',
@@ -312,6 +321,14 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
         'rule_id': 'SKY-E003',
         'message': "Unused file 'dead.ts'",
         'file': 'dead.ts',
+        'line': 1,
+    }
+    # Real skylos also reports the .mts/.cts/.mjs/.cjs module variants as
+    # SKY-E003; the inference must not stamp them SKY-E002.
+    assert defaulted_module_entry == {
+        'rule_id': 'SKY-E003',
+        'message': "Unused file 'dead.mjs'",
+        'file': 'dead.mjs',
         'line': 1,
     }
 

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -278,13 +278,6 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
                 kind='file',
                 bucket='unused_files',
             ),
-            FakeFinding(
-                path='dead.mjs',
-                line=1,
-                symbol='dead.mjs',
-                kind='file',
-                bucket='unused_files',
-            ),
         ],
         output_format='skylos',
     )
@@ -298,9 +291,7 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
     (variable_entry,) = document['unused_variables']
     assert 'rule_id' not in variable_entry
     assert variable_entry['name'] == 'y'
-    unused_file_entry, defaulted_python_entry, defaulted_typescript_entry, defaulted_module_entry = document[
-        'unused_files'
-    ]
+    unused_file_entry, defaulted_python_entry, defaulted_typescript_entry = document['unused_files']
     assert unused_file_entry == {
         'rule_id': 'SKY-E003',
         'message': 'Unused TypeScript/JavaScript file',
@@ -323,14 +314,14 @@ def test_main_emits_skylos_format_with_explicit_rule_ids(tmp_path: Path, capsys:
         'file': 'dead.ts',
         'line': 1,
     }
-    # Real skylos also reports the .mts/.cts/.mjs/.cjs module variants as
-    # SKY-E003; the inference must not stamp them SKY-E002.
-    assert defaulted_module_entry == {
-        'rule_id': 'SKY-E003',
-        'message': "Unused file 'dead.mjs'",
-        'file': 'dead.mjs',
-        'line': 1,
-    }
+
+
+@pytest.mark.parametrize('suffix', ['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs'])
+def test_fake_skylos_infers_e003_for_every_typescript_javascript_suffix(suffix: str) -> None:
+    """Infer the real Skylos unused-file rule for every TS/JS suffix."""
+    path = f'dead{suffix}'
+    entry = FakeFinding(path=path, line=1, symbol=path, kind='file', bucket='unused_files').skylos_entry()
+    assert entry['rule_id'] == 'SKY-E003'
 
 
 def test_main_skylos_format_clean_document(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -190,19 +190,19 @@ def test_skylos_parses_recorded_fixture() -> None:
     assert by_symbol['pkg.mod.orphan'].confidence == 100
     assert by_symbol['pkg.mod.orphan'].message == "unused function 'orphan'"
     assert by_symbol['pkg.mod.Greeter.farewell'].kind == 'method'
-    assert by_symbol['pkg.mod.os'].kind == 'import'
+    assert by_symbol['os'].kind == 'import'
     assert by_symbol['pkg.shapes.Hexagon'].kind == 'class'
-    assert by_symbol['pkg.consts.LEGACY_LIMIT'].kind == 'constant'
+    assert by_symbol['pkg.consts.LEGACY_LIMIT'].kind == 'variable'
     assert by_symbol['pkg.mod.orphan.flag'].kind == 'parameter'
-    assert by_symbol['pkg.mod.orphan.flag'].start_line == 4
+    assert by_symbol['pkg.mod.orphan.flag'].start_line == 7
     excerpt = by_symbol['pkg.mod.orphan'].raw_excerpt
     assert excerpt is not None
     assert json.loads(excerpt)['name'] == 'orphan'
     # Reporting contract §3.1: the documented bucket mapping supplies the
-    # canonical rule ID for every ingested category.
+    # canonical rule ID for every ingested symbol category.
     assert by_symbol['pkg.mod.orphan'].rule_id == 'SKY-U001'
     assert by_symbol['pkg.mod.Greeter.farewell'].rule_id == 'SKY-U001'
-    assert by_symbol['pkg.mod.os'].rule_id == 'SKY-U002'
+    assert by_symbol['os'].rule_id == 'SKY-U002'
     assert by_symbol['pkg.consts.LEGACY_LIMIT'].rule_id == 'SKY-U003'
     assert by_symbol['pkg.shapes.Hexagon'].rule_id == 'SKY-U004'
     assert by_symbol['pkg.mod.orphan.flag'].rule_id == 'SKY-U006'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -184,8 +184,8 @@ def test_vulture_symbols_may_contain_quotes() -> None:
 def test_skylos_parses_recorded_fixture() -> None:
     output = raw((FIXTURES / 'skylos_output.json').read_text(encoding='utf-8'))
     findings = SkylosAdapter.parse(output, project='demo', root=ROOT)
-    assert len(findings) == 6
-    by_symbol = {finding.symbol: finding for finding in findings}
+    assert len(findings) == 8
+    by_symbol = {finding.symbol: finding for finding in findings if finding.symbol is not None}
     assert by_symbol['pkg.mod.orphan'].kind == 'function'
     assert by_symbol['pkg.mod.orphan'].confidence == 100
     assert by_symbol['pkg.mod.orphan'].message == "unused function 'orphan'"
@@ -206,6 +206,15 @@ def test_skylos_parses_recorded_fixture() -> None:
     assert by_symbol['pkg.consts.LEGACY_LIMIT'].rule_id == 'SKY-U003'
     assert by_symbol['pkg.shapes.Hexagon'].rule_id == 'SKY-U004'
     assert by_symbol['pkg.mod.orphan.flag'].rule_id == 'SKY-U006'
+    # Reporting contract §3.1: `unused_files` is a multi-rule bucket whose
+    # entries carry their explicit rule IDs; there is no bucket fallback.
+    by_path = {finding.path: finding for finding in findings if finding.kind == 'file'}
+    assert by_path['pkg/blank.py'].rule_id == 'SKY-E002'
+    assert by_path['pkg/blank.py'].symbol is None
+    assert by_path['pkg/blank.py'].severity == 'LOW'
+    assert by_path['pkg/blank.py'].start_line == 1
+    assert by_path['pkg/orphan.ts'].rule_id == 'SKY-E003'
+    assert by_path['pkg/orphan.ts'].message == 'Unused TypeScript/JavaScript file (not imported by any other file)'
 
 
 def test_skylos_explicit_rule_id_takes_precedence_over_bucket_mapping() -> None:
@@ -234,7 +243,8 @@ def test_skylos_ingests_unused_files() -> None:
                 'category': 'DEAD_CODE',
             },
             {
-                'message': 'Empty Python file',
+                'rule_id': 'SKY-E002',
+                'message': 'Empty Python file (no code, or docstring-only)',
                 'file': 'pkg/zero.py',
                 'line': 0,
             },
@@ -244,25 +254,36 @@ def test_skylos_ingests_unused_files() -> None:
     findings = SkylosAdapter.parse(raw(json.dumps(document)), project='demo', root=ROOT)
 
     assert len(findings) == 2
-    explicit, mapped = findings
-    assert explicit.path == 'pkg/orphan.ts'
-    assert explicit.symbol is None
-    assert explicit.kind == 'file'
-    assert explicit.message == 'Unused TypeScript/JavaScript file (not imported by any other file)'
-    assert explicit.start_line == explicit.end_line == 1
-    assert explicit.confidence is None
-    assert explicit.severity == 'LOW'
-    assert explicit.rule_id == 'SKY-E003'
-    assert explicit.raw_excerpt is not None
-    assert 'category' not in json.loads(explicit.raw_excerpt)
-    assert mapped.path == 'pkg/zero.py'
-    assert mapped.start_line == mapped.end_line == 1
-    assert mapped.severity is None
-    assert mapped.rule_id == 'SKY-E002'
+    typescript, python = findings
+    assert typescript.path == 'pkg/orphan.ts'
+    assert typescript.symbol is None
+    assert typescript.kind == 'file'
+    assert typescript.message == 'Unused TypeScript/JavaScript file (not imported by any other file)'
+    assert typescript.start_line == typescript.end_line == 1
+    assert typescript.confidence is None
+    assert typescript.severity == 'LOW'
+    assert typescript.rule_id == 'SKY-E003'
+    assert typescript.raw_excerpt is not None
+    assert 'category' not in json.loads(typescript.raw_excerpt)
+    assert python.path == 'pkg/zero.py'
+    assert python.start_line == python.end_line == 1
+    assert python.severity is None
+    assert python.rule_id == 'SKY-E002'
 
 
-def test_skylos_rejects_malformed_unused_file_entries() -> None:
-    document = {'unused_files': [{'file': 'empty.py', 'line': 1}]}
+@pytest.mark.parametrize(
+    'entry',
+    [
+        # Guaranteed fields missing outright.
+        {'file': 'empty.py', 'line': 1},
+        # An entry without its explicit rule ID is malformed: `unused_files`
+        # is a multi-rule bucket with no fallback (reporting contract §3.1),
+        # so a defaulted code would corrupt the finding identity.
+        {'message': 'Empty Python file (no code, or docstring-only)', 'file': 'empty.py', 'line': 1},
+    ],
+)
+def test_skylos_rejects_malformed_unused_file_entries(entry: dict[str, object]) -> None:
+    document = {'unused_files': [entry]}
     with pytest.raises(AdapterError, match="malformed skylos entry in 'unused_files'"):
         SkylosAdapter.parse(raw(json.dumps(document)), project='demo', root=ROOT)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,7 +22,7 @@ from liveness_primer.tools.base import (
     build_invocation,
     normalize_finding_path,
 )
-from liveness_primer.tools.skylos import SkylosAdapter
+from liveness_primer.tools.skylos import DEAD_CODE_KEYS, SkylosAdapter
 from liveness_primer.tools.vulture import VultureAdapter
 
 FIXTURES = Path(__file__).parent / 'fixtures'
@@ -182,9 +182,21 @@ def test_vulture_symbols_may_contain_quotes() -> None:
 
 
 def test_skylos_parses_recorded_fixture() -> None:
-    output = raw((FIXTURES / 'skylos_output.json').read_text(encoding='utf-8'))
+    document = (FIXTURES / 'skylos_output.json').read_text(encoding='utf-8')
+    recorded = json.loads(document)
+    # Recorded Skylos 4.33.2 result buckets use absolute paths, while its
+    # nested evidence retains relative paths. Preserve that mixed raw shape.
+    assert all(Path(entry['file']).is_absolute() for key in DEAD_CODE_KEYS for entry in recorded[key])
+    evidence = recorded['dead_code_evidence']['symbols']
+    assert evidence
+    assert all(not Path(entry['file']).is_absolute() for entry in evidence)
+    scope = recorded['analysis_summary']['comparison_scope']
+    assert scope['repository_root'] == ROOT.as_posix()
+    assert scope['scan_path'] == ROOT.as_posix()
+    output = raw(document)
     findings = SkylosAdapter.parse(output, project='demo', root=ROOT)
     assert len(findings) == 8
+    assert all(not finding.path.startswith('/') for finding in findings)
     by_symbol = {finding.symbol: finding for finding in findings if finding.symbol is not None}
     assert by_symbol['pkg.mod.orphan'].kind == 'function'
     assert by_symbol['pkg.mod.orphan'].confidence == 100

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -222,6 +222,51 @@ def test_skylos_explicit_rule_id_takes_precedence_over_bucket_mapping() -> None:
     assert mapped.rule_id == 'SKY-U001'
 
 
+def test_skylos_ingests_unused_files() -> None:
+    document = {
+        'unused_files': [
+            {
+                'rule_id': 'SKY-E003',
+                'message': 'Unused TypeScript/JavaScript file (not imported by any other file)',
+                'file': '/checkout/pkg/orphan.ts',
+                'line': 1,
+                'severity': 'low',
+                'category': 'DEAD_CODE',
+            },
+            {
+                'message': 'Empty Python file',
+                'file': 'pkg/zero.py',
+                'line': 0,
+            },
+        ]
+    }
+
+    findings = SkylosAdapter.parse(raw(json.dumps(document)), project='demo', root=ROOT)
+
+    assert len(findings) == 2
+    explicit, mapped = findings
+    assert explicit.path == 'pkg/orphan.ts'
+    assert explicit.symbol is None
+    assert explicit.kind == 'file'
+    assert explicit.message == 'Unused TypeScript/JavaScript file (not imported by any other file)'
+    assert explicit.start_line == explicit.end_line == 1
+    assert explicit.confidence is None
+    assert explicit.severity == 'LOW'
+    assert explicit.rule_id == 'SKY-E003'
+    assert explicit.raw_excerpt is not None
+    assert 'category' not in json.loads(explicit.raw_excerpt)
+    assert mapped.path == 'pkg/zero.py'
+    assert mapped.start_line == mapped.end_line == 1
+    assert mapped.severity is None
+    assert mapped.rule_id == 'SKY-E002'
+
+
+def test_skylos_rejects_malformed_unused_file_entries() -> None:
+    document = {'unused_files': [{'file': 'empty.py', 'line': 1}]}
+    with pytest.raises(AdapterError, match="malformed skylos entry in 'unused_files'"):
+        SkylosAdapter.parse(raw(json.dumps(document)), project='demo', root=ROOT)
+
+
 @pytest.mark.parametrize(
     'document',
     [


### PR DESCRIPTION
## Summary

  - recognize Skylos `unused_files` as a dead-code result bucket
  - normalize file-level `SKY-E002` and `SKY-E003` findings
  - update the fake detector

  ## Why

Skylos emits empty and unused file findings under `unused_files`. However, the adapter did not ingest that bucket. The findings were therefore silently omitted from blast-radius comparisons.

  ## Tests

  - `  pytest test/test_liveness_primer_workflow.py test/test_github_actions_security.py`