### PR TITLE
fix: let -k override include_tools

### DIFF
--- a/liveness_primer/config.py
+++ b/liveness_primer/config.py
@@ -563,7 +563,8 @@ def select_projects(
     corpus : Corpus
         The validated corpus.
     tool : str
-        Adapter name the run targets; projects not supporting it are skipped.
+        Adapter name the run targets; ``-k`` may select a project omitted by
+        ``include_tools``, but never one that excludes the tool.
     keywords : Sequence[str]
         Substring selectors (``-k``), unioned.
     select_all : bool
@@ -589,7 +590,11 @@ def select_projects(
     if select_all:
         selected = applicable
     elif keywords:
-        selected = [project for project in applicable if any(keyword in project.name for keyword in keywords)]
+        selected = [
+            project
+            for project in corpus.projects
+            if tool not in project.exclude_tools and any(keyword in project.name for keyword in keywords)
+        ]
     else:
         selected = _select_by_cost(applicable, tool=tool, max_cost=max_cost if max_cost is not None else 0.0)
     if not selected:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -398,6 +398,17 @@ def test_select_by_keyword_substring_union() -> None:
     assert names == ['cheap', 'uncosted']
 
 
+def test_select_by_keyword_overrides_include_tools_but_not_exclude_tools() -> None:
+    corpus = Corpus(
+        projects=(
+            project('included', include_tools=('skylos',)),
+            project('excluded', include_tools=('skylos',), exclude_tools=('vulture',)),
+        )
+    )
+    names = [entry.name for entry in select_projects(corpus, tool='vulture', keywords=('ed',))]
+    assert names == ['included']
+
+
 def test_select_by_keyword_no_match_raises() -> None:
     with pytest.raises(CorpusConfigError, match='no corpus project matches'):
         select_projects(corpus_for_selection(), tool='vulture', keywords=('nomatch',))


### PR DESCRIPTION
## Summary

- Let explicit -k corpus selection bypass include_tools.
- Preserve exclude_tools as a hard exclusion.

## Tests

- .venv/bin/pytest -q
- .venv/bin/prek run --all-files
- .venv/bin/mypy --explicit-package-bases .
- .venv/bin/pyright --pythonpath .venv/bin/python