### PR TITLE
docs: restore skill purpose in review-liveness-pr description

### DIFF
--- a/.agents/skills/review-liveness-pr/SKILL.md
+++ b/.agents/skills/review-liveness-pr/SKILL.md
@@ -1,16 +1,9 @@
 ---
 name: review-liveness-pr
-description: CI or manual invocation only. Use only when the user explicitly invokes $review-liveness-pr or a designated liveness_primer CI workflow invokes it. Never auto-select this skill for a general pull-request review, even when a liveness_primer artifact is available.
+description: Review an existing liveness_primer JSON artifact against a pull request's stated intent and produce a concise advisory report with one conclusion, optional verdict flags, confidence, review priority, and specific finding evidence. Support every liveness_primer adapter. Never rerun the detector or liveness_primer. Opt-in only: use solely when the user explicitly invokes $review-liveness-pr or the designated liveness_primer CI workflow invokes it; never auto-select this skill for a general pull-request review, even when a liveness_primer artifact is available.
 ---
 
 # Review a liveness_primer pull request
-
-## Activation boundary
-
-Use this skill only after an explicit ``$review-liveness-pr`` invocation or
-from the designated liveness_primer CI workflow. A general pull-request review
-does not authorize this workflow, even when a liveness_primer artifact is
-available.
 
 Produce a read-only advisory review of an existing liveness_primer JSON report.
 Return concise GitHub-flavored Markdown followed by an embedded machine-readable


### PR DESCRIPTION
## Summary

Follow-up to #46. That PR replaced the whole `review-liveness-pr` frontmatter `description` with the opt-in gate, which left nothing in the description saying what the skill actually does.

Skill dispatch matches on the description, so an explicit `$review-liveness-pr` invocation had no purpose text to match against, and the "never rerun the detector or liveness_primer" constraint was dropped from the summary line.

## What changed

- Restored the descriptive `description` text and appended the opt-in gate as a trailing clause, so the frontmatter states both what the skill does and when it may be selected.
- Removed the now-redundant `## Activation boundary` body section; the same rule is stated in the description and in `AGENTS.md`.

Gating semantics are unchanged: still opt-in via explicit `$review-liveness-pr` or the designated CI workflow, still never auto-selected for a general PR review. `AGENTS.md` is untouched.

## AI assistance

Details: Assisted with authoring the commit and PR; the change itself was already prepared and was reviewed before publication.