### PR TITLE
feat: add ignore include tools selector

### DIFF
--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -126,7 +126,9 @@ point*: pre-triage, triage, or post-triage (§10).
   selections for every selected project otherwise. The reserved name `none` (alone)
   selects no analyses; empty names are rejected.
 - Selection: by name (`-k`), `--all`, or `--max-cost SECONDS` (greedy under declared cost
-  for the chosen tool).
+  for the chosen tool). `--all` and `--max-cost` select only projects whose include/exclude
+  tool lists admit the chosen tool, unless `--ignore-include-tools` is given; `-k` always
+  ignores `include_tools`. `exclude_tools` is absolute under every selector.
 - The initial corpus list is deferred to a Phase 1 task (~5–10 permissively licensed,
   actively maintained, moderate-size projects).
 
@@ -253,7 +255,8 @@ point*: pre-triage, triage, or post-triage (§10).
 printing the package version and `SCHEMA_VERSION`. Commands:
 
 - `run --tool T --repo URL --old REF --new REF [-k SEL | --all | --max-cost S]
-  [--max-results N] [--excerpt-lines N] [--output text|json|github] [--fail-on ...]
+  [--ignore-include-tools] [--max-results N] [--excerpt-lines N]
+  [--output text|json|github] [--fail-on ...]
   [--jobs N] [--timeout S] [--fresh] [--old-cmd CMD --new-cmd CMD] [--project URL]
   [--analyses NAME[,NAME...]]`
 - `corpus validate` — parse and validate the corpus YAML.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Report and manifest payloads carry their own `schema_version`, versioned
 independently of the package version; `liveness-primer --version` prints both.
 
+## [Unreleased]
+
+### Added
+
+- **Corpus selection** — `--ignore-include-tools` lets `--all` and `--max-cost`
+  consider projects their `include_tools` omits, so a one-off comparison needs no
+  corpus edit. `--max-cost` still selects a project only if it declares a cost for
+  the tool being run.
+
+### Changed
+
+- **Corpus selection** — `-k` now selects a matching project even when the
+  project's `include_tools` omits the tool being run. `exclude_tools` remains a
+  hard exclusion under every selector.
+
 ## [0.1.0] - 2026-08-14
 
 This is the first release version of `liveness_primer`, so everything is new.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Project selection is explicit:
 - `--project URL` compares against one ad-hoc target repository instead of the
   packaged corpus.
 
+With `--all` or `--max-cost`, `--ignore-include-tools` also considers projects
+omitted by `include_tools`. An `exclude_tools` entry still prevents the tool
+from running, and budgeted selection skips projects without a declared cost.
+
 ### Reading the result
 
 | Result | Meaning | What to investigate |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Project selection is explicit:
 
 With `--all` or `--max-cost`, `--ignore-include-tools` also considers projects
 omitted by `include_tools`. An `exclude_tools` entry still prevents the tool
-from running, and budgeted selection skips projects without a declared cost.
+from running, and `--max-cost` selects a project only if it declares a cost for
+the tool being run, including the projects this flag admits.
 
 ### Reading the result
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,8 +52,9 @@ Repeated `-k` options are combined into one selection. Do not combine that
 mode with `--all` or `--max-cost`, and do not combine `--project` with any
 corpus selector. With `--all` or `--max-cost`, add `--ignore-include-tools`
 to also consider projects omitted by `include_tools`; `exclude_tools` still
-prevents a tool from running. Budgeted selection continues to skip projects
-without a declared cost for that tool.
+prevents a tool from running. Budgeted selection continues to skip any project
+that declares no cost for the tool being run, including the projects
+`--ignore-include-tools` admits.
 
 ## Interpret the result
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,7 +50,10 @@ Every run requires exactly one target-selection mode:
 
 Repeated `-k` options are combined into one selection. Do not combine that
 mode with `--all` or `--max-cost`, and do not combine `--project` with any
-corpus selector.
+corpus selector. With `--all` or `--max-cost`, add `--ignore-include-tools`
+to also consider projects omitted by `include_tools`; `exclude_tools` still
+prevents a tool from running. Budgeted selection continues to skip projects
+without a declared cost for that tool.
 
 ## Interpret the result
 

--- a/liveness_primer/cli.py
+++ b/liveness_primer/cli.py
@@ -433,7 +433,7 @@ def _select_run_projects(args: argparse.Namespace) -> tuple[CorpusProject, ...]:
     analyses = _resolve_analyses(args)
     if args.project_url is not None:
         if args.keywords or args.select_all or args.max_cost is not None or args.ignore_include_tools:
-            msg = '--project (ad-hoc mode) does not take corpus selection options'
+            msg = '--project (ad-hoc mode) does not take -k/--all/--max-cost/--ignore-include-tools'
             raise RunnerError(msg)
         return (ad_hoc_project(args.project_url, tool=args.tool, analyses=analyses if analyses is not None else ()),)
     corpus = load_corpus(args.corpus, known_tools=adapter_names(), known_analyses=adapter_analyses())

--- a/liveness_primer/cli.py
+++ b/liveness_primer/cli.py
@@ -179,6 +179,11 @@ def _add_run_parser(subcommands: 'argparse._SubParsersAction[argparse.ArgumentPa
     run_parser.add_argument('--all', dest='select_all', action='store_true', help='select every applicable project')
     run_parser.add_argument('--max-cost', type=_positive_float, help='greedy selection budget in CPU-seconds')
     run_parser.add_argument(
+        '--ignore-include-tools',
+        action='store_true',
+        help='consider projects omitted by include_tools with --all or --max-cost',
+    )
+    run_parser.add_argument(
         '--corpus', type=Path, default=default_corpus_path(), help='corpus YAML file (default: the packaged corpus)'
     )
     run_parser.add_argument('--project', dest='project_url', help='ad-hoc mode: single target repository URL')
@@ -427,8 +432,8 @@ def _select_run_projects(args: argparse.Namespace) -> tuple[CorpusProject, ...]:
     """
     analyses = _resolve_analyses(args)
     if args.project_url is not None:
-        if args.keywords or args.select_all or args.max_cost is not None:
-            msg = '--project (ad-hoc mode) does not take -k/--all/--max-cost'
+        if args.keywords or args.select_all or args.max_cost is not None or args.ignore_include_tools:
+            msg = '--project (ad-hoc mode) does not take corpus selection options'
             raise RunnerError(msg)
         return (ad_hoc_project(args.project_url, tool=args.tool, analyses=analyses if analyses is not None else ()),)
     corpus = load_corpus(args.corpus, known_tools=adapter_names(), known_analyses=adapter_analyses())
@@ -438,6 +443,7 @@ def _select_run_projects(args: argparse.Namespace) -> tuple[CorpusProject, ...]:
         keywords=tuple(args.keywords),
         select_all=args.select_all,
         max_cost=args.max_cost,
+        ignore_include_tools=args.ignore_include_tools,
     )
     if analyses is None:
         return selected

--- a/liveness_primer/config.py
+++ b/liveness_primer/config.py
@@ -550,6 +550,7 @@ def select_projects(
     keywords: Sequence[str] = (),
     select_all: bool = False,
     max_cost: float | None = None,
+    ignore_include_tools: bool = False,
 ) -> tuple[CorpusProject, ...]:
     """Select corpus projects for a run (contract §5).
 
@@ -571,6 +572,9 @@ def select_projects(
         Select every applicable project (``--all``).
     max_cost : float | None
         Cost budget in CPU-seconds (``--max-cost``).
+    ignore_include_tools : bool
+        Include projects omitted by ``include_tools`` with ``--all`` or
+        ``--max-cost``; ``exclude_tools`` remains effective.
 
     Returns
     -------
@@ -586,15 +590,15 @@ def select_projects(
     if active != 1:
         msg = 'exactly one of -k, --all, or --max-cost must be given'
         raise CorpusConfigError(msg)
-    applicable = [project for project in corpus.projects if project.supports_tool(tool)]
+    if ignore_include_tools and keywords:
+        msg = '--ignore-include-tools does not apply to -k, which already ignores include_tools'
+        raise CorpusConfigError(msg)
+    eligible = [project for project in corpus.projects if tool not in project.exclude_tools]
+    applicable = eligible if ignore_include_tools else [project for project in eligible if project.supports_tool(tool)]
     if select_all:
         selected = applicable
     elif keywords:
-        selected = [
-            project
-            for project in corpus.projects
-            if tool not in project.exclude_tools and any(keyword in project.name for keyword in keywords)
-        ]
+        selected = [project for project in eligible if any(keyword in project.name for keyword in keywords)]
     else:
         selected = _select_by_cost(applicable, tool=tool, max_cost=max_cost if max_cost is not None else 0.0)
     if not selected:

--- a/liveness_primer/config.py
+++ b/liveness_primer/config.py
@@ -202,9 +202,10 @@ class CorpusProject(_ConfigModel):
     tools : dict[str, ToolSettings]
         Per-tool tables keyed by adapter name.
     include_tools : tuple[str, ...] | None
-        When set, only these tools run against the project.
+        When set, only these tools select the project by default; ``-k`` and
+        ``--ignore-include-tools`` select past it.
     exclude_tools : tuple[str, ...]
-        Tools that never run against the project.
+        Tools that never run against the project, under every selector.
     """
 
     name: str = Field(pattern=r'^[A-Za-z0-9._-]+$')
@@ -236,7 +237,10 @@ class CorpusProject(_ConfigModel):
         return self
 
     def supports_tool(self, tool: str) -> bool:
-        """Report whether a tool participates for this project (contract §5).
+        """Report whether a tool participates by default for this project (contract §5).
+
+        Blanket selectors honor this predicate unless ``--ignore-include-tools``
+        is given; ``-k`` honors only ``exclude_tools``.
 
         Parameters
         ----------
@@ -573,8 +577,9 @@ def select_projects(
     max_cost : float | None
         Cost budget in CPU-seconds (``--max-cost``).
     ignore_include_tools : bool
-        Include projects omitted by ``include_tools`` with ``--all`` or
-        ``--max-cost``; ``exclude_tools`` remains effective.
+        Also consider projects omitted by ``include_tools`` with ``--all`` or
+        ``--max-cost``; no effect with ``-k``, which already ignores the list.
+        ``exclude_tools`` remains effective.
 
     Returns
     -------
@@ -589,9 +594,6 @@ def select_projects(
     active = sum((bool(keywords), select_all, max_cost is not None))
     if active != 1:
         msg = 'exactly one of -k, --all, or --max-cost must be given'
-        raise CorpusConfigError(msg)
-    if ignore_include_tools and keywords:
-        msg = '--ignore-include-tools does not apply to -k, which already ignores include_tools'
         raise CorpusConfigError(msg)
     eligible = [project for project in corpus.projects if tool not in project.exclude_tools]
     applicable = eligible if ignore_include_tools else [project for project in eligible if project.supports_tool(tool)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,8 +227,13 @@ def test_run_mode_flag_matrix_errors(tmp_path: Path, capsys: pytest.CaptureFixtu
     del tmp_path
 
 
-def test_run_rejects_ad_hoc_with_selectors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    argv = escape_argv(tmp_path, 'https://example.invalid/x', [], [], '--all')
+@pytest.mark.parametrize('corpus_option', ['--all', '--ignore-include-tools'])
+def test_run_rejects_ad_hoc_with_corpus_options(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    corpus_option: str,
+) -> None:
+    argv = escape_argv(tmp_path, 'https://example.invalid/x', [], [], corpus_option)
     assert main(argv) == EXIT_FAILURE
     assert 'ad-hoc mode' in capsys.readouterr().err
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -393,6 +393,30 @@ def test_select_all_filters_tool_support() -> None:
     assert names == ['cheap', 'mid', 'pricey', 'uncosted']
 
 
+def test_select_all_and_max_cost_can_ignore_include_tools() -> None:
+    corpus = Corpus(
+        projects=(
+            project('enabled', tools={'vulture': {'cost': 5.0}}),
+            project('disabled-cheap', include_tools=('skylos',), tools={'vulture': {'cost': 2.0}}),
+            project('disabled-pricey', include_tools=('skylos',), tools={'vulture': {'cost': 10.0}}),
+            project(
+                'excluded',
+                include_tools=('skylos',),
+                exclude_tools=('vulture',),
+                tools={'vulture': {'cost': 1.0}},
+            ),
+        )
+    )
+    all_names = [
+        entry.name for entry in select_projects(corpus, tool='vulture', select_all=True, ignore_include_tools=True)
+    ]
+    budgeted_names = [
+        entry.name for entry in select_projects(corpus, tool='vulture', max_cost=2.0, ignore_include_tools=True)
+    ]
+    assert all_names == ['enabled', 'disabled-cheap', 'disabled-pricey']
+    assert budgeted_names == ['disabled-cheap']
+
+
 def test_select_by_keyword_substring_union() -> None:
     names = [entry.name for entry in select_projects(corpus_for_selection(), tool='vulture', keywords=('chea', 'cost'))]
     assert names == ['cheap', 'uncosted']
@@ -407,6 +431,16 @@ def test_select_by_keyword_overrides_include_tools_but_not_exclude_tools() -> No
     )
     names = [entry.name for entry in select_projects(corpus, tool='vulture', keywords=('ed',))]
     assert names == ['included']
+
+
+def test_ignore_include_tools_rejects_keyword_selection() -> None:
+    with pytest.raises(CorpusConfigError, match='does not apply'):
+        select_projects(
+            corpus_for_selection(),
+            tool='vulture',
+            keywords=('cheap',),
+            ignore_include_tools=True,
+        )
 
 
 def test_select_by_keyword_no_match_raises() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -433,14 +433,15 @@ def test_select_by_keyword_overrides_include_tools_but_not_exclude_tools() -> No
     assert names == ['included']
 
 
-def test_ignore_include_tools_rejects_keyword_selection() -> None:
-    with pytest.raises(CorpusConfigError, match='does not apply'):
-        select_projects(
-            corpus_for_selection(),
-            tool='vulture',
-            keywords=('cheap',),
-            ignore_include_tools=True,
+def test_ignore_include_tools_is_accepted_and_inert_for_keyword_selection() -> None:
+    corpus = Corpus(
+        projects=(
+            project('included', include_tools=('skylos',)),
+            project('excluded', include_tools=('skylos',), exclude_tools=('vulture',)),
         )
+    )
+    selected = select_projects(corpus, tool='vulture', keywords=('ed',), ignore_include_tools=True)
+    assert [entry.name for entry in selected] == ['included']
 
 
 def test_select_by_keyword_no_match_raises() -> None:


### PR DESCRIPTION
## Summary

- Add --ignore-include-tools for --all and --max-cost corpus selection.
- Keep exclude_tools as a hard exclusion and reject the redundant -k combination.
- Document that budgeted selection skips projects without a declared tool cost.

## Tests

- .venv/bin/pytest -q
- .venv/bin/prek run --all-files
- .venv/bin/mypy --explicit-package-bases .
- .venv/bin/pyright --pythonpath .venv/bin/python