### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Report and manifest payloads carry their own `schema_version`, versioned
 independently of the package version; `liveness-primer --version` prints both.
 
-## [Unreleased]
+## [0.1.1] - 2026-08-21
 
 ### Added
 
@@ -16,8 +16,8 @@ independently of the package version; `liveness-primer --version` prints both.
   consider projects their `include_tools` omits, so a one-off comparison needs no
   corpus edit. `--max-cost` still selects a project only if it declares a cost for
   the tool being run.
-- **Corpus Entires** - For vulture target, added xarray, meltano-sdk, fluids, todo,
-  copyparty, elementary, beartype, strawberry, scrapy, and bokeh.
+- **Vulture corpus** — Add xarray, meltano-sdk, fluids, todo, copyparty,
+  elementary, beartype, strawberry, scrapy, and bokeh.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ independently of the package version; `liveness-primer --version` prints both.
   consider projects their `include_tools` omits, so a one-off comparison needs no
   corpus edit. `--max-cost` still selects a project only if it declares a cost for
   the tool being run.
+- **Corpus Entires** - For vulture target, added xarray, meltano-sdk, fluids, todo,
+  copyparty, elementary, beartype, strawberry, scrapy, and bokeh.
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
 title: "liveness_primer"
-version: 0.1.0
-date-released: 2026-08-14
+version: 0.1.1
+date-released: 2026-08-21
 abstract: "Differential testing harness for Python dead-code detectors and static linters: run a detector at two revisions across a corpus and diff the findings"
 authors:
   - family-names: "Digman"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liveness_primer"
-version = "0.1.0"
+version = "0.1.1"
 description = "Differential testing harness for Python dead-code detectors and static linters: run a detector at two revisions across a corpus and diff the findings."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "liveness-primer"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

Prepares the 0.1.1 package release, including the existing local changelog commit (03d103e) for the expanded Vulture corpus.

## What changed

- Releases the Unreleased notes as 0.1.1 dated 2026-08-21.
- Aligns Python package, citation, and uv lockfile metadata at 0.1.1.

## Verification

```
.venv/bin/prek run --all-files  # passed
.venv/bin/pytest                # 588 passed, 3 skipped
metadata consistency check       # passed
```

## Release checklist

- [x] Package and citation versions agree at 0.1.1.
- [x] CITATION.cff release date set to 2026-08-21.
- [x] CHANGELOG.md released as 0.1.1.
- [ ] After merge, publish GitHub Release v0.1.1; publish.yml will build and publish the artifacts.

## AI assistance

Details: Codex prepared the release metadata and ran the stated local checks; maintainer review remains required.