### PR TITLE
Use Coveralls for measured coverage badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,13 +78,15 @@ jobs:
           .venv/bin/python -m coverage xml
           .venv/bin/python -m coverage html
 
+      # The implicit success gate prevents partial reports from failed tests
+      # reaching the public badge. Coveralls availability is advisory.
       - name: Upload coverage to Coveralls
-        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329  # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.xml
           format: cobertura
+          fail-on-error: false
           coverage-reporter-version: v0.6.17
 
       - name: Upload coverage reports

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,6 +78,15 @@ jobs:
           .venv/bin/python -m coverage xml
           .venv/bin/python -m coverage html
 
+      - name: Upload coverage to Coveralls
+        if: ${{ !cancelled() }}
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329  # v2.3.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml
+          format: cobertura
+          coverage-reporter-version: v0.6.17
+
       - name: Upload coverage reports
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PyPI](https://img.shields.io/pypi/v/liveness-primer.svg)](https://pypi.org/project/liveness-primer/)
-[![Coverage: 100%](https://img.shields.io/github/actions/workflow/status/mcdigman/liveness_primer/coverage.yml?branch=main&event=push&label=coverage%3A%20100%25)](https://github.com/mcdigman/liveness_primer/actions/workflows/coverage.yml)
+[![Coverage Status](https://coveralls.io/repos/github/mcdigman/liveness_primer/badge.svg?branch=main)](https://coveralls.io/github/mcdigman/liveness_primer?branch=main)
 [![Test](https://github.com/mcdigman/liveness_primer/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/mcdigman/liveness_primer/actions/workflows/test.yml)
 [![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/downloads/)
 


### PR DESCRIPTION
## Summary

- upload the generated Cobertura `coverage.xml` report with the pinned official Coveralls GitHub Action
- pin the Coveralls coverage reporter used by the action
- replace the fixed 100% workflow-status badge with the measured Coveralls badge for `main`
- authenticate with GitHub's built-in `GITHUB_TOKEN`; no custom Coveralls repository token is required

## Validation

- `.venv/bin/prek run --all-files`
- GitHub Actions workflow YAML parsed successfully
- `git diff --check`
