### PR TITLE
chore: prefer Ruff rule codes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
   - id: ssort
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.18
+  rev: v0.16.3
   hooks:
   - id: ruff-check
     args: [--fix, --preview]

--- a/ruff.toml
+++ b/ruff.toml
@@ -34,9 +34,11 @@ indent-width = 4
 # Assume Python 3.12
 target-version = "py312"
 
+output-prefer-rule-codes = true
+
 [lint]
 select = ["ALL"]
-ignore = ["SIM108", "COM812", "PLR2004", "PLR0912", "PLR0913", "PLR0915", "RUF069", "PLR0914", "PLR0917"]
+ignore = ["SIM108", "COM812", "PLR2004", "PLR0912", "PLR0913", "PLR0915", "RUF069", "PLR0914", "PLR0917", "RUF201"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
## Summary

- prefer Ruff rule codes in lint output
- ignore the preview rule that recommends named selectors
- align the Ruff pre-commit hook with Ruff 0.16.3

## Validation

- `prek run --all-files`