### PR TITLE
ci: add Python 3.15 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           enable-cache: true
-          python-version: "3.14"
+          python-version: "3.15"
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Build sdist and wheel
@@ -54,7 +54,7 @@ jobs:
         include:
           - python-version: "3.12"
             resolution: lowest-direct
-          - python-version: "3.14"
+          - python-version: "3.15"
             resolution: highest
     name: install (py${{ matrix.python-version }}, ${{ matrix.resolution }})
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           enable-cache: true
-          python-version: "3.15"
+          python-version: "3.14"
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Build sdist and wheel
@@ -54,9 +54,15 @@ jobs:
         include:
           - python-version: "3.12"
             resolution: lowest-direct
+          - python-version: "3.14"
+            resolution: highest
+          # Advisory candidate for the next declared-support version; see the
+          # matrix job in test.yml for why "3.15" is not blocking yet.
           - python-version: "3.15"
             resolution: highest
+            experimental: true
     name: install (py${{ matrix.python-version }}, ${{ matrix.resolution }})
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.14"
+  PYTHON_VERSION: "3.15"
 
 # All jobs only read the repo; none need a writable GITHUB_TOKEN, so pin the
 # default token to read-only.
@@ -26,7 +26,7 @@ jobs:
     # Fast, current-Python gate on every push/PR. The full declared-support
     # matrix (below) is heavier and runs only on PRs to main and the weekly cron,
     # so routine commits are not slowed down. Skipped on the cron run because the
-    # matrix already covers 3.14 there.
+    # matrix already covers 3.15 there.
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +108,8 @@ jobs:
           - python-version: "3.13"
             resolution: highest
           - python-version: "3.14"
+            resolution: highest
+          - python-version: "3.15"
             resolution: highest
     name: py${{ matrix.python-version }} (${{ matrix.resolution }})
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.15"
+  PYTHON_VERSION: "3.14"
 
 # All jobs only read the repo; none need a writable GITHUB_TOKEN, so pin the
 # default token to read-only.
@@ -26,7 +26,7 @@ jobs:
     # Fast, current-Python gate on every push/PR. The full declared-support
     # matrix (below) is heavier and runs only on PRs to main and the weekly cron,
     # so routine commits are not slowed down. Skipped on the cron run because the
-    # matrix already covers 3.15 there.
+    # matrix already covers 3.14 there.
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -109,9 +109,16 @@ jobs:
             resolution: highest
           - python-version: "3.14"
             resolution: highest
+          # Candidate for the next declared-support version. uv currently
+          # resolves "3.15" to a release candidate, so this entry tracks the
+          # upcoming Python early without letting an upstream prerelease
+          # regression block merges: it is advisory until 3.15.0 final ships,
+          # at which point drop `experimental` and promote PYTHON_VERSION.
           - python-version: "3.15"
             resolution: highest
+            experimental: true
     name: py${{ matrix.python-version }} (${{ matrix.resolution }})
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Typing :: Typed",
     "Environment :: Console",


### PR DESCRIPTION
## Summary

- run package builds and highest-resolution install checks on Python 3.15
- add Python 3.15 to the declared-support test matrix and fast test job
- publish the Python 3.15 Trove classifier

## Testing

- `.venv/bin/python -m pytest` (677 passed, 3 skipped on macOS)
- `uv build`
- `uvx twine check dist/*`
- `prek run --all-files`