### PR TITLE
feat(container): stage admitted native helpers

### DIFF
--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -35,7 +35,8 @@ point*: pre-triage, triage, or post-triage (§10).
   Docker:
   - **Images:** each ref installs into a fingerprint-keyed environment image. The key
     covers the repository and resolved SHA, adapter build recipe, exact builder and
-    runtime image references, adapter-declared runtime artifacts, and Docker identity.
+    runtime image references, adapter-declared runtime artifacts, admitted native-helper
+    identities, and Docker identity.
     Builder and runtime images must report matching Python versions and architectures,
     and the result must expose the managed virtual-environment interpreter. An offline
     multi-stage `docker build --network none` installs the detector as a non-root user,
@@ -56,8 +57,9 @@ point*: pre-triage, triage, or post-triage (§10).
   - **Caching and compatibility:** Docker images are cached; `--fresh` bypasses the build
     cache, while paired same-run dependency resolution is unchanged. The Docker CLI and
     image-override requirements are specified in §12 and §17. Operator-supplied native
-    helper executables (§4 `passthrough_env`) are refused because host binaries cannot run
-    inside the container.
+    helper executables (§4 `passthrough_env`) must be 64-bit Linux ELF binaries whose
+    machine matches the probed image architecture. Each admitted helper's digest is part
+    of the image fingerprint, and identical revalidated bytes are staged into both images.
 - Three-step runs: a **fetch** step (network permitted; git clones plus dependency prefetch
   into a local wheel cache, wheels preferred; detector-ref dependencies are resolved by
   statically parsing `[project.dependencies]`/`[project.optional-dependencies]` and
@@ -125,7 +127,9 @@ point*: pre-triage, triage, or post-triage (§10).
   `passthrough_env`: names of operator-supplied environment variables carrying native
   helper executables the detector needs (skylos's `SKYLOS_GO_BIN`); the runner resolves,
   validates, and hashes each supplied binary into the manifest, and both sides receive
-  the identical helper. Skylos still
+  the identical helper. In container mode it additionally validates a 64-bit Linux ELF
+  machine matching the runtime image, snapshots the helper into both images, and passes
+  the container path instead of its host path. Skylos still
   merges a target `.skylos/config.yaml`, which can enable unselected analyses and affect
   execution cost, exit status, timeouts, and run completeness; revisions predating the
   variable can likewise discover target configuration. Parse-side gating protects report

--- a/.contracts/initial_contract.md
+++ b/.contracts/initial_contract.md
@@ -58,8 +58,10 @@ point*: pre-triage, triage, or post-triage (§10).
     cache, while paired same-run dependency resolution is unchanged. The Docker CLI and
     image-override requirements are specified in §12 and §17. Operator-supplied native
     helper executables (§4 `passthrough_env`) must be 64-bit Linux ELF binaries whose
-    machine matches the probed image architecture. Each admitted helper's digest is part
-    of the image fingerprint, and identical revalidated bytes are staged into both images.
+    machine matches the probed image architecture. Platform validation and the admitted
+    digest apply to the same byte stream before cache lookup; each staged copy is checked
+    again. The digest is part of the image fingerprint, and identical bytes are staged into
+    both images.
 - Three-step runs: a **fetch** step (network permitted; git clones plus dependency prefetch
   into a local wheel cache, wheels preferred; detector-ref dependencies are resolved by
   statically parsing `[project.dependencies]`/`[project.optional-dependencies]` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ independently of the package version; `liveness-primer --version` prints both.
 - **Container runtime tools** — adapters can declare pinned runtime
   executables. Skylos includes a digest-verified static ripgrep executable for
   grep verification; Vulture requires none.
+- **Container native helpers** — operator-supplied helpers such as
+  `SKYLOS_GO_BIN` are digest-pinned into both images after validation as 64-bit
+  Linux ELF executables for the selected container architecture.
 - **Vulture corpus** — Add prowler-sdk, mne-python, mcp-context-forge, psutil,
   pandas, qtile, redis-py, and Vulture's own self-analysis. Each reproduces the
   Vulture invocation its project commits upstream, so these are the first

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,8 +155,9 @@ following compatibility rules apply:
   which its pinned ripgrep executable is available.
 - `--fresh` forces image rebuilds.
 - `--old-cmd` and `--new-cmd` cannot be combined with `--container`.
-- Host executables supplied through variables such as `SKYLOS_GO_BIN` are not
-  supported because they cannot run inside the container.
+- Host executables supplied through variables such as `SKYLOS_GO_BIN` are
+  digest-pinned and copied into both environment images. They must be built
+  for the selected container platform.
 
 ## Use pre-built detector commands
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,8 +156,9 @@ following compatibility rules apply:
 - `--fresh` forces image rebuilds.
 - `--old-cmd` and `--new-cmd` cannot be combined with `--container`.
 - Host executables supplied through variables such as `SKYLOS_GO_BIN` are
-  digest-pinned and copied into both environment images. They must be built
-  for the selected container platform.
+  digest-pinned and copied into both environment images. They must be 64-bit
+  Linux ELF executables built for, and otherwise runnable on, the selected
+  container architecture.
 
 ## Use pre-built detector commands
 

--- a/liveness_primer/container.py
+++ b/liveness_primer/container.py
@@ -695,6 +695,23 @@ def stage_static_binary(
 
 
 def _native_tool_header_and_digest(stream: BinaryIO) -> tuple[bytes, str]:
+    """Read one helper's ELF header prefix and whole-file digest together.
+
+    Taking both from a single open stream binds the validated header to the
+    admitted digest: the bytes that pass the platform check are the same
+    bytes the digest comparison accepts.
+
+    Parameters
+    ----------
+    stream : BinaryIO
+        Binary stream positioned at the start of the helper.
+
+    Returns
+    -------
+    tuple[bytes, str]
+        The leading header bytes, short only when the helper ends first,
+        and the SHA-256 of everything read.
+    """
     header = stream.read(_ELF_HEADER_PREFIX_BYTES)
     digest = hashlib.sha256(header)
     for chunk in iter(lambda: stream.read(_NATIVE_TOOL_DIGEST_CHUNK_BYTES), b''):
@@ -703,6 +720,25 @@ def _native_tool_header_and_digest(stream: BinaryIO) -> tuple[bytes, str]:
 
 
 def _container_native_tool_target(machine: str) -> tuple[str, int]:
+    """Resolve the ELF machine an admitted helper must declare.
+
+    Parameters
+    ----------
+    machine : str
+        Runtime image architecture.
+
+    Returns
+    -------
+    tuple[str, int]
+        Canonical architecture name, and the ELF ``e_machine`` value a
+        helper must carry to run on it.
+
+    Raises
+    ------
+    ContainerError
+        If the container architecture has no pinned ELF machine, so no
+        helper can be admitted for it.
+    """
     architecture = _normalized_architecture(machine)
     expected_machine = _ELF_MACHINE_BY_ARCHITECTURE.get(architecture)
     if expected_machine is None:
@@ -718,6 +754,25 @@ def _validate_container_native_tool_header(
     expected_machine: int,
     description: str,
 ) -> None:
+    """Require one ELF header prefix to describe a runnable helper.
+
+    Parameters
+    ----------
+    header : bytes
+        Leading header bytes of the helper.
+    architecture : str
+        Canonical container architecture, named in the mismatch message.
+    expected_machine : int
+        ELF ``e_machine`` value the container architecture requires.
+    description : str
+        Operator-facing name of the helper.
+
+    Raises
+    ------
+    ContainerError
+        If the header is not a 64-bit little-endian Linux ELF executable
+        built for the container architecture.
+    """
     if len(header) < _ELF_HEADER_PREFIX_BYTES:
         msg = f'{description} is not a supported 64-bit Linux ELF executable'
         raise ContainerError(msg)
@@ -776,7 +831,18 @@ def validate_container_native_tool_platform(tool: ContainerNativeTool, machine: 
 
 
 def _validate_container_native_tool_platforms(tools: tuple[ContainerNativeTool, ...], machine: str) -> None:
-    """Validate every admitted helper against one container architecture."""
+    """Validate every admitted helper against one container architecture.
+
+    Runs before any cache lookup, clone, or fetch, so an unusable helper
+    fails the run before it costs an image build.
+
+    Parameters
+    ----------
+    tools : tuple[ContainerNativeTool, ...]
+        Admitted helpers, empty when the operator supplied none.
+    machine : str
+        Runtime image architecture.
+    """
     for tool in tools:
         validate_container_native_tool_platform(tool, machine)
 

--- a/liveness_primer/container.py
+++ b/liveness_primer/container.py
@@ -176,6 +176,10 @@ CONTAINER_WORK_ROOT = PurePosixPath('/liveness/work')
 # keeps it distinct from host filesystem paths governed by tempfile.
 CONTAINER_TMP_ROOT = PurePosixPath('/') / 'tmp'
 
+# Container-side directory for operator-supplied native helpers. The helper's
+# adapter-declared variable becomes its filename and points here at runtime.
+CONTAINER_NATIVE_TOOL_ROOT = PurePosixPath('/liveness/native-tools')
+
 _DOCKER_TIMEOUT = 1800.0
 
 # Cache-format / security revision of the environment image. Bump whenever the
@@ -235,6 +239,7 @@ FROM {runtime_image}
 COPY --from=builder /liveness/venv /liveness/venv
 COPY --from=builder /liveness/freeze.txt /liveness/freeze.txt
 {runtime_binary_copies}
+{native_tool_copies}
 ENV PATH="/liveness/venv/bin:$PATH"
 ENTRYPOINT []
 """
@@ -242,6 +247,35 @@ ENTRYPOINT []
 
 class ContainerError(LivenessPrimerError):
     """Raised when the Docker runtime cannot prepare or run an environment."""
+
+
+@dataclass(frozen=True, slots=True)
+class ContainerNativeTool:
+    """One admitted native helper to snapshot into both images.
+
+    Attributes
+    ----------
+    variable : str
+        Adapter-declared environment variable carrying the helper.
+    source : Path
+        Admitted host executable to snapshot.
+    sha256 : str
+        Digest recorded when the helper was admitted.
+    """
+
+    variable: str
+    source: Path
+    sha256: str
+
+    @property
+    def container_path(self) -> PurePosixPath:
+        """Helper path inside an environment image."""
+        return CONTAINER_NATIVE_TOOL_ROOT / self.variable
+
+    @property
+    def identity(self) -> str:
+        """Helper identity used by fingerprints and manifests."""
+        return f'{self.variable} sha256:{self.sha256}'
 
 
 def _validate_cache_directory(path: Path) -> None:
@@ -447,6 +481,7 @@ def container_fingerprint(
     builder_image: str,
     runtime_image: str,
     runtime_binary_identities: tuple[str, ...],
+    native_tool_identities: tuple[str, ...] = (),
 ) -> str:
     """Compute the environment fingerprint of one containerized ref (contract §3).
 
@@ -467,6 +502,8 @@ def container_fingerprint(
     runtime_binary_identities : tuple[str, ...]
         Version, architecture, and exact binary digest of every
         adapter-declared runtime utility.
+    native_tool_identities : tuple[str, ...]
+        Variable and exact digest of every admitted native helper.
 
     Returns
     -------
@@ -486,6 +523,7 @@ def container_fingerprint(
             'runtime': docker_identity,
             'runtime_image': runtime_image,
             'runtime_binaries': runtime_binary_identities,
+            'native_tools': native_tool_identities,
         },
         sort_keys=True,
     )
@@ -621,6 +659,29 @@ def stage_static_binary(source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(source, destination)
     destination.chmod(0o555)
+
+
+def stage_container_native_tool(tool: ContainerNativeTool, destination: Path) -> None:
+    """Snapshot and revalidate one admitted helper in a build context.
+
+    Parameters
+    ----------
+    tool : ContainerNativeTool
+        Admitted helper and its comparison-constant digest.
+    destination : Path
+        Build-context path to create.
+
+    Raises
+    ------
+    ContainerError
+        If the helper changed after admission.
+    """
+    stage_static_binary(tool.source, destination)
+    with destination.open('rb') as stream:
+        actual_digest = hashlib.file_digest(stream, 'sha256').hexdigest()
+    if actual_digest != tool.sha256:
+        msg = f'native helper {tool.variable} changed after admission: expected {tool.sha256}, got {actual_digest}'
+        raise ContainerError(msg)
 
 
 def _validate_prefetched_binary(path: Path, expected_digest: str) -> None:
@@ -1505,6 +1566,7 @@ class ContainerEnvironments:
         checkout: Path,
         wheelhouses: Sequence[Path],
         runtime_binaries: Mapping[RuntimeBinary, Callable[[], Path]],
+        native_tools: tuple[ContainerNativeTool, ...],
     ) -> None:
         """Build one environment image from an offline context (build step, §3, §11).
 
@@ -1521,6 +1583,8 @@ class ContainerEnvironments:
         runtime_binaries : Mapping[RuntimeBinary, Callable[[], Path]]
             Lazy providers of the adapter-declared, verified static binaries
             shared by both side builds.
+        native_tools : tuple[ContainerNativeTool, ...]
+            Admitted helpers to snapshot identically into both side images.
 
         Raises
         ------
@@ -1539,12 +1603,18 @@ class ContainerEnvironments:
             stage_wheelhouses(wheelhouses, context / 'wheelhouse')
             for binary, provider in runtime_binaries.items():
                 stage_static_binary(provider(), context / 'tools' / binary)
+            for tool in native_tools:
+                stage_container_native_tool(tool, context / 'native-tools' / tool.variable)
             runtime_binary_copies = '\n'.join(f'COPY tools/{binary} /usr/bin/{binary}' for binary in runtime_binaries)
+            native_tool_copies = '\n'.join(
+                f'COPY native-tools/{tool.variable} {tool.container_path}' for tool in native_tools
+            )
             dockerfile = _DOCKERFILE.format(
                 builder_image=self._builder_image,
                 runtime_image=self._runtime_image,
                 build_user=_BUILD_USER,
                 runtime_binary_copies=runtime_binary_copies,
+                native_tool_copies=native_tool_copies,
             )
             (context / 'Dockerfile').write_text(dockerfile, encoding='utf-8')
             self._docker.build_image(tag, context, fresh=self._fresh)
@@ -1558,6 +1628,7 @@ class ContainerEnvironments:
         fingerprint: str,
         wheelhouses: Callable[[], Sequence[Path]],
         runtime_binaries: Mapping[RuntimeBinary, Callable[[], Path]],
+        native_tools: tuple[ContainerNativeTool, ...],
         expected_python_version: str,
         force_rebuild: bool,
     ) -> ContainerEnvHandle:
@@ -1578,6 +1649,8 @@ class ContainerEnvironments:
             its fetch on first build.
         runtime_binaries : Mapping[RuntimeBinary, Callable[[], Path]]
             Lazy providers of the verified static runtime binaries.
+        native_tools : tuple[ContainerNativeTool, ...]
+            Admitted helpers to snapshot into the image.
         expected_python_version : str
             Version the builder and runtime image preflight both reported.
         force_rebuild : bool
@@ -1599,7 +1672,7 @@ class ContainerEnvironments:
         if not cached:
             houses = wheelhouses()
             checkout = self._store.materialize(repo, sha)
-            self._build(tag, checkout, houses, runtime_binaries)
+            self._build(tag, checkout, houses, runtime_binaries, native_tools)
         environment_python_version = self._docker.environment_python_version(tag)
         if environment_python_version != expected_python_version:
             msg = (
@@ -1619,7 +1692,13 @@ class ContainerEnvironments:
 
     @contextlib.contextmanager
     def prepare_pair(
-        self, repo: str, base_ref: str, head_ref: str, adapter: DetectorAdapter
+        self,
+        repo: str,
+        base_ref: str,
+        head_ref: str,
+        adapter: DetectorAdapter,
+        *,
+        native_tools: tuple[ContainerNativeTool, ...] = (),
     ) -> Iterator[PreparedContainerPair]:
         """Prepare both environment images and run their ephemeral containers (contract §3, §11).
 
@@ -1653,6 +1732,8 @@ class ContainerEnvironments:
             Head ref as requested on the CLI.
         adapter : DetectorAdapter
             Adapter of the tool under test.
+        native_tools : tuple[ContainerNativeTool, ...]
+            Operator-supplied helpers admitted before image preparation.
 
         Yields
         ------
@@ -1677,6 +1758,7 @@ class ContainerEnvironments:
             self._builder_image,
             self._runtime_image,
             image_pair.runtime_binary_identities,
+            tuple(tool.identity for tool in native_tools),
         )
         head_fingerprint = container_fingerprint(
             repo,
@@ -1686,6 +1768,7 @@ class ContainerEnvironments:
             self._builder_image,
             self._runtime_image,
             image_pair.runtime_binary_identities,
+            tuple(tool.identity for tool in native_tools),
         )
         pair_key = hashlib.sha256(f'{base_fingerprint}:{head_fingerprint}'.encode()).hexdigest()[:24]
         wheelhouse_root = self._cache_dir / 'wheelhouse-container'
@@ -1816,6 +1899,7 @@ class ContainerEnvironments:
                     fingerprint=base_fingerprint,
                     wheelhouses=base_wheelhouses,
                     runtime_binaries=runtime_binary_providers,
+                    native_tools=native_tools,
                     expected_python_version=image_pair.python_version,
                     force_rebuild=force,
                 ),
@@ -1826,6 +1910,7 @@ class ContainerEnvironments:
                     fingerprint=head_fingerprint,
                     wheelhouses=head_wheelhouses,
                     runtime_binaries=runtime_binary_providers,
+                    native_tools=native_tools,
                     expected_python_version=image_pair.python_version,
                     force_rebuild=force,
                 ),
@@ -1851,6 +1936,7 @@ class ContainerEnvironments:
                         f'builder {self._builder_image}',
                         f'runtime {self._runtime_image}',
                         *image_pair.runtime_binary_identities,
+                        *(tool.identity for tool in native_tools),
                     )
                 ),
                 python_version=image_pair.python_version,

--- a/liveness_primer/container.py
+++ b/liveness_primer/container.py
@@ -180,6 +180,18 @@ CONTAINER_TMP_ROOT = PurePosixPath('/') / 'tmp'
 # adapter-declared variable becomes its filename and points here at runtime.
 CONTAINER_NATIVE_TOOL_ROOT = PurePosixPath('/liveness/native-tools')
 
+_ELF_HEADER_PREFIX_BYTES = 20
+_ELF64_LITTLE_ENDIAN_IDENT = b'\x7fELF\x02\x01\x01'
+_LINUX_ELF_OS_ABIS = frozenset({0, 3})
+_ELF_EXECUTABLE_TYPES = frozenset({2, 3})
+_ELF_MACHINE_BY_ARCHITECTURE: Mapping[str, int] = {
+    'x86_64': 62,
+    'aarch64': 183,
+}
+_ARCHITECTURE_BY_ELF_MACHINE: Mapping[int, str] = {
+    machine: architecture for architecture, machine in _ELF_MACHINE_BY_ARCHITECTURE.items()
+}
+
 _DOCKER_TIMEOUT = 1800.0
 
 # Cache-format / security revision of the environment image. Bump whenever the
@@ -633,7 +645,37 @@ def _static_binary_identity(artifact: StaticBinaryArtifact) -> str:
     )
 
 
-def stage_static_binary(source: Path, destination: Path) -> None:
+def _require_regular_source(source: Path, *, description: str) -> None:
+    """Require one build-context source to be a regular, non-symlink file.
+
+    Parameters
+    ----------
+    source : Path
+        Host path to inspect without following symlinks.
+    description : str
+        Operator-facing name of the source kind.
+
+    Raises
+    ------
+    ContainerError
+        If the source is missing, a symlink, or not a regular file.
+    """
+    try:
+        status = source.lstat()
+    except FileNotFoundError as error:
+        msg = f'{description} is missing: {source.name}'
+        raise ContainerError(msg) from error
+    if stat.S_ISLNK(status.st_mode) or not stat.S_ISREG(status.st_mode):
+        msg = f'{description} is not a regular file: {source.name}'
+        raise ContainerError(msg)
+
+
+def stage_static_binary(
+    source: Path,
+    destination: Path,
+    *,
+    source_description: str = 'prefetched static binary',
+) -> None:
     """Copy one verified static binary into an offline build context.
 
     Parameters
@@ -642,23 +684,70 @@ def stage_static_binary(source: Path, destination: Path) -> None:
         Fresh output of the runtime's digest-verifying fetch operation.
     destination : Path
         Build-context path to create.
+    source_description : str
+        Operator-facing name of the source kind.
+    """
+    _require_regular_source(source, description=source_description)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    destination.chmod(0o555)
+
+
+def validate_container_native_tool_platform(tool: ContainerNativeTool, machine: str) -> None:
+    """Require an admitted helper to target the container architecture.
+
+    Parameters
+    ----------
+    tool : ContainerNativeTool
+        Admitted helper to inspect.
+    machine : str
+        Runtime image architecture.
 
     Raises
     ------
     ContainerError
-        If the fetch output is missing, a symlink, or not a regular file.
+        If the helper is not a supported Linux ELF executable for the
+        runtime image architecture.
     """
-    try:
-        status = source.lstat()
-    except FileNotFoundError as error:
-        msg = f'prefetched static binary is missing: {source.name}'
-        raise ContainerError(msg) from error
-    if stat.S_ISLNK(status.st_mode) or not stat.S_ISREG(status.st_mode):
-        msg = f'prefetched static binary is not a regular file: {source.name}'
+    architecture = _normalized_architecture(machine)
+    expected_machine = _ELF_MACHINE_BY_ARCHITECTURE.get(architecture)
+    if expected_machine is None:
+        msg = f'container architecture {machine!r} cannot admit native helpers'
         raise ContainerError(msg)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(source, destination)
-    destination.chmod(0o555)
+
+    description = f'native helper {tool.variable}'
+    _require_regular_source(tool.source, description=description)
+    try:
+        with tool.source.open('rb') as stream:
+            header = stream.read(_ELF_HEADER_PREFIX_BYTES)
+    except OSError as error:
+        msg = f'cannot read {description}: {error}'
+        raise ContainerError(msg) from error
+    if len(header) < _ELF_HEADER_PREFIX_BYTES:
+        msg = f'{description} is not a supported 64-bit Linux ELF executable'
+        raise ContainerError(msg)
+    if header[: len(_ELF64_LITTLE_ENDIAN_IDENT)] != _ELF64_LITTLE_ENDIAN_IDENT:
+        msg = f'{description} is not a supported 64-bit Linux ELF executable'
+        raise ContainerError(msg)
+    if header[7] not in _LINUX_ELF_OS_ABIS:
+        msg = f'{description} is not a supported 64-bit Linux ELF executable'
+        raise ContainerError(msg)
+    elf_type = int.from_bytes(header[16:18], byteorder='little')
+    if elf_type not in _ELF_EXECUTABLE_TYPES:
+        msg = f'{description} is not a supported 64-bit Linux ELF executable'
+        raise ContainerError(msg)
+
+    actual_machine = int.from_bytes(header[18:20], byteorder='little')
+    if actual_machine != expected_machine:
+        actual_architecture = _ARCHITECTURE_BY_ELF_MACHINE.get(actual_machine, f'ELF machine {actual_machine}')
+        msg = f'{description} targets {actual_architecture}, not container architecture {architecture}'
+        raise ContainerError(msg)
+
+
+def _validate_container_native_tool_platforms(tools: tuple[ContainerNativeTool, ...], machine: str) -> None:
+    """Validate every admitted helper against one container architecture."""
+    for tool in tools:
+        validate_container_native_tool_platform(tool, machine)
 
 
 def stage_container_native_tool(tool: ContainerNativeTool, destination: Path) -> None:
@@ -676,7 +765,7 @@ def stage_container_native_tool(tool: ContainerNativeTool, destination: Path) ->
     ContainerError
         If the helper changed after admission.
     """
-    stage_static_binary(tool.source, destination)
+    stage_static_binary(tool.source, destination, source_description=f'native helper {tool.variable}')
     with destination.open('rb') as stream:
         actual_digest = hashlib.file_digest(stream, 'sha256').hexdigest()
     if actual_digest != tool.sha256:
@@ -1248,6 +1337,7 @@ class ContainerEnvHandle:
 class _ImagePairProbe:
     """Compatible builder/runtime image properties used by preparation."""
 
+    architecture: str
     docker_identity: str
     python_version: str
     platform: str
@@ -1468,6 +1558,7 @@ class ContainerEnvironments:
         }
         identities = tuple(_static_binary_identity(artifact) for artifact in artifacts.values())
         return _ImagePairProbe(
+            architecture=_normalized_architecture(runtime_architecture),
             docker_identity=docker_identity,
             python_version=runtime_python_version,
             platform=self._docker.platform(self._runtime_image),
@@ -1748,6 +1839,7 @@ class ContainerEnvironments:
             container cannot be confirmed after a successful analysis.
         """
         image_pair = self._probe_images(adapter)
+        _validate_container_native_tool_platforms(native_tools, image_pair.architecture)
         base_sha, head_sha, ref_fetches = resolve_pair_refs(self._store, repo, base_ref, head_ref)
         self._fetches.extend(ref_fetches)
         base_fingerprint = container_fingerprint(

--- a/liveness_primer/container.py
+++ b/liveness_primer/container.py
@@ -29,7 +29,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from functools import cache, partial
 from pathlib import Path, PurePosixPath
-from typing import Literal, Protocol, runtime_checkable
+from typing import BinaryIO, Literal, Protocol, runtime_checkable
 
 from filelock import BaseFileLock, FileLock, Timeout
 
@@ -181,6 +181,7 @@ CONTAINER_TMP_ROOT = PurePosixPath('/') / 'tmp'
 CONTAINER_NATIVE_TOOL_ROOT = PurePosixPath('/liveness/native-tools')
 
 _ELF_HEADER_PREFIX_BYTES = 20
+_NATIVE_TOOL_DIGEST_CHUNK_BYTES = 1_048_576
 _ELF64_LITTLE_ENDIAN_IDENT = b'\x7fELF\x02\x01\x01'
 _LINUX_ELF_OS_ABIS = frozenset({0, 3})
 _ELF_EXECUTABLE_TYPES = frozenset({2, 3})
@@ -693,36 +694,30 @@ def stage_static_binary(
     destination.chmod(0o555)
 
 
-def validate_container_native_tool_platform(tool: ContainerNativeTool, machine: str) -> None:
-    """Require an admitted helper to target the container architecture.
+def _native_tool_header_and_digest(stream: BinaryIO) -> tuple[bytes, str]:
+    header = stream.read(_ELF_HEADER_PREFIX_BYTES)
+    digest = hashlib.sha256(header)
+    for chunk in iter(lambda: stream.read(_NATIVE_TOOL_DIGEST_CHUNK_BYTES), b''):
+        digest.update(chunk)
+    return header, digest.hexdigest()
 
-    Parameters
-    ----------
-    tool : ContainerNativeTool
-        Admitted helper to inspect.
-    machine : str
-        Runtime image architecture.
 
-    Raises
-    ------
-    ContainerError
-        If the helper is not a supported Linux ELF executable for the
-        runtime image architecture.
-    """
+def _container_native_tool_target(machine: str) -> tuple[str, int]:
     architecture = _normalized_architecture(machine)
     expected_machine = _ELF_MACHINE_BY_ARCHITECTURE.get(architecture)
     if expected_machine is None:
         msg = f'container architecture {machine!r} cannot admit native helpers'
         raise ContainerError(msg)
+    return architecture, expected_machine
 
-    description = f'native helper {tool.variable}'
-    _require_regular_source(tool.source, description=description)
-    try:
-        with tool.source.open('rb') as stream:
-            header = stream.read(_ELF_HEADER_PREFIX_BYTES)
-    except OSError as error:
-        msg = f'cannot read {description}: {error}'
-        raise ContainerError(msg) from error
+
+def _validate_container_native_tool_header(
+    header: bytes,
+    *,
+    architecture: str,
+    expected_machine: int,
+    description: str,
+) -> None:
     if len(header) < _ELF_HEADER_PREFIX_BYTES:
         msg = f'{description} is not a supported 64-bit Linux ELF executable'
         raise ContainerError(msg)
@@ -744,13 +739,49 @@ def validate_container_native_tool_platform(tool: ContainerNativeTool, machine: 
         raise ContainerError(msg)
 
 
+def validate_container_native_tool_platform(tool: ContainerNativeTool, machine: str) -> None:
+    """Require admitted bytes to target the container architecture.
+
+    Parameters
+    ----------
+    tool : ContainerNativeTool
+        Admitted helper to inspect.
+    machine : str
+        Runtime image architecture.
+
+    Raises
+    ------
+    ContainerError
+        If the helper changed after admission or is not a supported Linux
+        ELF executable for the runtime image architecture.
+    """
+    architecture, expected_machine = _container_native_tool_target(machine)
+    description = f'native helper {tool.variable}'
+    _require_regular_source(tool.source, description=description)
+    try:
+        with tool.source.open('rb') as stream:
+            header, actual_digest = _native_tool_header_and_digest(stream)
+    except OSError as error:
+        msg = f'cannot read {description}: {error}'
+        raise ContainerError(msg) from error
+    if actual_digest != tool.sha256:
+        msg = f'{description} changed after admission: expected {tool.sha256}, got {actual_digest}'
+        raise ContainerError(msg)
+    _validate_container_native_tool_header(
+        header,
+        architecture=architecture,
+        expected_machine=expected_machine,
+        description=description,
+    )
+
+
 def _validate_container_native_tool_platforms(tools: tuple[ContainerNativeTool, ...], machine: str) -> None:
     """Validate every admitted helper against one container architecture."""
     for tool in tools:
         validate_container_native_tool_platform(tool, machine)
 
 
-def stage_container_native_tool(tool: ContainerNativeTool, destination: Path) -> None:
+def stage_container_native_tool(tool: ContainerNativeTool, destination: Path, *, machine: str) -> None:
     """Snapshot and revalidate one admitted helper in a build context.
 
     Parameters
@@ -759,18 +790,29 @@ def stage_container_native_tool(tool: ContainerNativeTool, destination: Path) ->
         Admitted helper and its comparison-constant digest.
     destination : Path
         Build-context path to create.
+    machine : str
+        Runtime image architecture.
 
     Raises
     ------
     ContainerError
-        If the helper changed after admission.
+        If the helper changed after admission or its staged bytes are not a
+        supported Linux ELF executable for the runtime image architecture.
     """
+    architecture, expected_machine = _container_native_tool_target(machine)
+    description = f'native helper {tool.variable}'
     stage_static_binary(tool.source, destination, source_description=f'native helper {tool.variable}')
     with destination.open('rb') as stream:
-        actual_digest = hashlib.file_digest(stream, 'sha256').hexdigest()
+        header, actual_digest = _native_tool_header_and_digest(stream)
     if actual_digest != tool.sha256:
-        msg = f'native helper {tool.variable} changed after admission: expected {tool.sha256}, got {actual_digest}'
+        msg = f'{description} changed after admission: expected {tool.sha256}, got {actual_digest}'
         raise ContainerError(msg)
+    _validate_container_native_tool_header(
+        header,
+        architecture=architecture,
+        expected_machine=expected_machine,
+        description=description,
+    )
 
 
 def _validate_prefetched_binary(path: Path, expected_digest: str) -> None:
@@ -1658,6 +1700,7 @@ class ContainerEnvironments:
         wheelhouses: Sequence[Path],
         runtime_binaries: Mapping[RuntimeBinary, Callable[[], Path]],
         native_tools: tuple[ContainerNativeTool, ...],
+        machine: str,
     ) -> None:
         """Build one environment image from an offline context (build step, §3, §11).
 
@@ -1676,6 +1719,8 @@ class ContainerEnvironments:
             shared by both side builds.
         native_tools : tuple[ContainerNativeTool, ...]
             Admitted helpers to snapshot identically into both side images.
+        machine : str
+            Runtime image architecture.
 
         Raises
         ------
@@ -1695,7 +1740,11 @@ class ContainerEnvironments:
             for binary, provider in runtime_binaries.items():
                 stage_static_binary(provider(), context / 'tools' / binary)
             for tool in native_tools:
-                stage_container_native_tool(tool, context / 'native-tools' / tool.variable)
+                stage_container_native_tool(
+                    tool,
+                    context / 'native-tools' / tool.variable,
+                    machine=machine,
+                )
             runtime_binary_copies = '\n'.join(f'COPY tools/{binary} /usr/bin/{binary}' for binary in runtime_binaries)
             native_tool_copies = '\n'.join(
                 f'COPY native-tools/{tool.variable} {tool.container_path}' for tool in native_tools
@@ -1720,6 +1769,7 @@ class ContainerEnvironments:
         wheelhouses: Callable[[], Sequence[Path]],
         runtime_binaries: Mapping[RuntimeBinary, Callable[[], Path]],
         native_tools: tuple[ContainerNativeTool, ...],
+        machine: str,
         expected_python_version: str,
         force_rebuild: bool,
     ) -> ContainerEnvHandle:
@@ -1742,6 +1792,8 @@ class ContainerEnvironments:
             Lazy providers of the verified static runtime binaries.
         native_tools : tuple[ContainerNativeTool, ...]
             Admitted helpers to snapshot into the image.
+        machine : str
+            Runtime image architecture.
         expected_python_version : str
             Version the builder and runtime image preflight both reported.
         force_rebuild : bool
@@ -1763,7 +1815,7 @@ class ContainerEnvironments:
         if not cached:
             houses = wheelhouses()
             checkout = self._store.materialize(repo, sha)
-            self._build(tag, checkout, houses, runtime_binaries, native_tools)
+            self._build(tag, checkout, houses, runtime_binaries, native_tools, machine)
         environment_python_version = self._docker.environment_python_version(tag)
         if environment_python_version != expected_python_version:
             msg = (
@@ -1992,6 +2044,7 @@ class ContainerEnvironments:
                     wheelhouses=base_wheelhouses,
                     runtime_binaries=runtime_binary_providers,
                     native_tools=native_tools,
+                    machine=image_pair.architecture,
                     expected_python_version=image_pair.python_version,
                     force_rebuild=force,
                 ),
@@ -2003,6 +2056,7 @@ class ContainerEnvironments:
                     wheelhouses=head_wheelhouses,
                     runtime_binaries=runtime_binary_providers,
                     native_tools=native_tools,
+                    machine=image_pair.architecture,
                     expected_python_version=image_pair.python_version,
                     force_rebuild=force,
                 ),

--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -26,6 +26,7 @@ from liveness_primer.config import CorpusProject, ToolSettings
 from liveness_primer.container import (
     ContainerEnvironments,
     ContainerExecution,
+    ContainerNativeTool,
     PreparedContainerPair,
     container_user,
     stage_invocation_env_files,
@@ -414,6 +415,9 @@ class PrimerRunner:
         # the identical binary.
         admitted = resolve_native_tools(adapter, os.environ if environ is None else environ)
         self._passthrough_env = {tool.variable: tool.path for tool in admitted}
+        self._container_native_tools = tuple(
+            ContainerNativeTool(variable=tool.variable, source=Path(tool.path), sha256=tool.sha256) for tool in admitted
+        )
         self._native_tools = tuple(tool.record() for tool in admitted)
         self._adapter = adapter
         self._store = store
@@ -990,17 +994,14 @@ class PrimerRunner:
         Report
             The blast radius.
 
-        Raises
-        ------
-        RunnerError
-            If an operator-supplied native helper was admitted: a host
-            executable cannot run inside the container.
         """
-        if self._passthrough_env:
-            names = ', '.join(sorted(self._passthrough_env))
-            msg = f'native helper passthrough ({names}) is not supported in --container mode'
-            raise RunnerError(msg)
-        with environments.prepare_pair(detector_repo, base_ref, head_ref, self._adapter) as pair:
+        with environments.prepare_pair(
+            detector_repo,
+            base_ref,
+            head_ref,
+            self._adapter,
+            native_tools=self._container_native_tools,
+        ) as pair:
             # Declared env files exist only on the host; each side gets an
             # identical copy under its mount, at one container-side path.
             env_files = stage_invocation_env_files(
@@ -1009,7 +1010,11 @@ class PrimerRunner:
             execution = ContainerExecution(
                 work_roots={'base': pair.base_work_root, 'head': pair.head_work_root},
                 images={'base': pair.base.image, 'head': pair.head.image},
-                invocation_env={**self._adapter.invocation_env, **env_files},
+                invocation_env={
+                    **self._adapter.invocation_env,
+                    **env_files,
+                    **{tool.variable: str(tool.container_path) for tool in self._container_native_tools},
+                },
                 docker=environments.runtime,
                 active_containers=pair.active_containers,
                 user=container_user(),

--- a/liveness_primer/tools/base.py
+++ b/liveness_primer/tools/base.py
@@ -150,10 +150,12 @@ class DetectorAdapter(Protocol):
         Environment variables naming an operator-supplied native helper
         executable the detector needs. The §3 scrub drops everything
         unlisted, so a declared variable is the only way an operator sets
-        one for the analysis invocation (the build step does not receive
-        them); the runner validates and hashes each value and records it in
-        the manifest. A detector may still locate a helper by its own
-        means — bundled in its install, or on the surviving ``PATH``.
+        one for the analysis invocation (the detector build stage does not
+        receive them); the runner validates and hashes each value and records
+        it in the manifest. Container mode snapshots a compatible Linux ELF
+        helper into each runtime image. A detector may still locate a helper
+        by its own means — bundled in its install, or on the surviving
+        ``PATH``.
     runtime_binaries : tuple[RuntimeBinary, ...]
         Static executables staged into a minimal container runtime. Empty for
         a pure-Python detector.

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -169,7 +169,8 @@ class SkylosAdapter:
         incompletely without it, and on revisions that surface that as an
         analysis error the invocation fails outright. Both sides receive
         the same operator-supplied binary, so the engine is a constant of
-        the comparison rather than part of the diff.
+        the comparison rather than part of the diff. Container mode
+        snapshots it into both environment images after digest validation.
     runtime_binaries : tuple[RuntimeBinary, ...]
         ``rg`` for grep verification in minimal container runtimes.
     success_exit_codes : frozenset[int]

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -37,6 +37,7 @@ from liveness_primer.container import (
     stage_invocation_env_files,
     stage_static_binary,
     stage_wheelhouses,
+    validate_container_native_tool_platform,
 )
 from liveness_primer.corpus import CheckoutStore
 from liveness_primer.execution import SideWorkspace
@@ -392,6 +393,31 @@ def test_ripgrep_artifact_for_rejects_unsupported_architecture() -> None:
         ripgrep_artifact_for('s390x')
 
 
+def write_linux_elf(
+    path: Path,
+    architecture: Literal['aarch64', 'x86_64'],
+    *,
+    elf_type: int = 2,
+    os_abi: int = 0,
+) -> Path:
+    """Write the ELF header prefix used by native-helper admission tests.
+
+    Returns
+    -------
+    Path
+        Executable test-file path.
+    """
+    machine = {'x86_64': 62, 'aarch64': 183}[architecture]
+    header = bytearray(20)
+    header[:7] = b'\x7fELF\x02\x01\x01'
+    header[7] = os_abi
+    header[16:18] = elf_type.to_bytes(2, byteorder='little')
+    header[18:20] = machine.to_bytes(2, byteorder='little')
+    atomic_write_bytes(path, bytes(header))
+    path.chmod(0o755)
+    return path
+
+
 def test_stage_static_binary_copies_only_a_regular_file(tmp_path: Path) -> None:
     source = tmp_path / 'source' / 'rg'
     source.parent.mkdir()
@@ -443,6 +469,81 @@ def test_stage_container_native_tool_revalidates_the_admitted_digest(tmp_path: P
     atomic_write_bytes(source, b'changed-engine')
     with pytest.raises(ContainerError, match='SKYLOS_GO_BIN changed after admission'):
         stage_container_native_tool(tool, tmp_path / 'second-context' / tool.variable)
+
+
+def test_stage_container_native_tool_names_an_invalid_operator_source(tmp_path: Path) -> None:
+    missing = tmp_path / 'skylos-go'
+    tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=missing, sha256='a' * 64)
+    with pytest.raises(ContainerError, match='native helper SKYLOS_GO_BIN is missing: skylos-go'):
+        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable)
+
+    target = tmp_path / 'engine'
+    atomic_write_bytes(target, b'engine')
+    missing.symlink_to(target)
+    with pytest.raises(ContainerError, match='native helper SKYLOS_GO_BIN is not a regular file: skylos-go'):
+        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable)
+
+
+@pytest.mark.parametrize('machine', ['aarch64', 'arm64'])
+def test_validate_container_native_tool_accepts_matching_linux_elf(tmp_path: Path, machine: str) -> None:
+    source = write_linux_elf(tmp_path / 'skylos-go', 'aarch64')
+    tool = ContainerNativeTool(
+        variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+    validate_container_native_tool_platform(tool, machine)
+
+
+@pytest.mark.parametrize(
+    ('payload', 'detail'),
+    [
+        (b'', 'not a supported 64-bit Linux ELF executable'),
+        (b'x' * 20, 'not a supported 64-bit Linux ELF executable'),
+    ],
+)
+def test_validate_container_native_tool_rejects_invalid_elf(tmp_path: Path, payload: bytes, detail: str) -> None:
+    source = tmp_path / 'skylos-go'
+    atomic_write_bytes(source, payload)
+    tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(payload).hexdigest())
+    with pytest.raises(ContainerError, match=detail):
+        validate_container_native_tool_platform(tool, 'aarch64')
+
+
+@pytest.mark.parametrize(('elf_type', 'os_abi'), [(2, 9), (1, 0)])
+def test_validate_container_native_tool_rejects_non_executable_or_non_linux_elf(
+    tmp_path: Path, elf_type: int, os_abi: int
+) -> None:
+    source = write_linux_elf(tmp_path / 'skylos-go', 'aarch64', elf_type=elf_type, os_abi=os_abi)
+    tool = ContainerNativeTool(
+        variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+    with pytest.raises(ContainerError, match='not a supported 64-bit Linux ELF executable'):
+        validate_container_native_tool_platform(tool, 'aarch64')
+
+
+def test_validate_container_native_tool_rejects_wrong_or_unsupported_architecture(tmp_path: Path) -> None:
+    source = write_linux_elf(tmp_path / 'skylos-go', 'x86_64')
+    tool = ContainerNativeTool(
+        variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+    with pytest.raises(ContainerError, match='targets x86_64, not container architecture aarch64'):
+        validate_container_native_tool_platform(tool, 'aarch64')
+    with pytest.raises(ContainerError, match="container architecture 's390x' cannot admit native helpers"):
+        validate_container_native_tool_platform(tool, 's390x')
+
+
+def test_validate_container_native_tool_wraps_read_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = write_linux_elf(tmp_path / 'skylos-go', 'aarch64')
+    tool = ContainerNativeTool(
+        variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+
+    def deny_open(_path: Path, _mode: str) -> None:
+        message = 'denied'
+        raise PermissionError(message)
+
+    monkeypatch.setattr(Path, 'open', deny_open)
+    with pytest.raises(ContainerError, match='cannot read native helper SKYLOS_GO_BIN: denied'):
+        validate_container_native_tool_platform(tool, 'aarch64')
 
 
 def requirement_wheel(requirement: str) -> str:
@@ -835,6 +936,30 @@ def test_cached_pair_skips_builds(tmp_path: Path, detector_repo: DetectorRepo) -
     assert docker.prefetches == []
     assert docker.ripgrep_prefetches == []
     assert pair.environment_delta == ()
+
+
+def test_native_tool_platform_is_validated_before_cached_pair_reuse(
+    tmp_path: Path, detector_repo: DetectorRepo
+) -> None:
+    source = write_linux_elf(tmp_path / 'skylos-go', 'x86_64')
+    tool = ContainerNativeTool(
+        variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+    docker = FakeDocker(always_cached=True)
+    with (
+        pytest.raises(ContainerError, match='targets x86_64, not container architecture aarch64'),
+        environments(tmp_path, docker).prepare_pair(
+            detector_repo.url,
+            'base-branch',
+            'head-branch',
+            VultureAdapter(),
+            native_tools=(tool,),
+        ),
+    ):
+        pass
+    assert 'inspect' not in docker.events
+    assert docker.prefetches == []
+    assert docker.built == []
 
 
 def test_cached_delta_triggers_paired_same_run_rebuild(tmp_path: Path, detector_repo: DetectorRepo) -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -24,6 +24,7 @@ from liveness_primer.container import (
     ContainerEnvironments,
     ContainerError,
     ContainerExecution,
+    ContainerNativeTool,
     DockerCli,
     DockerRuntime,
     StaticBinaryArtifact,
@@ -32,6 +33,7 @@ from liveness_primer.container import (
     image_tag,
     promote_prefetched,
     ripgrep_artifact_for,
+    stage_container_native_tool,
     stage_invocation_env_files,
     stage_static_binary,
     stage_wheelhouses,
@@ -344,6 +346,16 @@ def test_container_fingerprint_varies_by_inputs() -> None:
     assert base != container_fingerprint(
         'https://r', 'a' * 40, adapter, 'docker 27', 'builder:1', 'runtime:1', ('ripgrep:2',)
     )
+    assert base != container_fingerprint(
+        'https://r',
+        'a' * 40,
+        adapter,
+        'docker 27',
+        'builder:1',
+        'runtime:1',
+        ('ripgrep:1',),
+        ('SKYLOS_GO_BIN sha256:1234',),
+    )
 
 
 def test_container_fingerprint_tracks_the_cache_format(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -412,6 +424,25 @@ def test_stage_static_binaries_share_one_tools_directory(tmp_path: Path) -> None
     stage_static_binary(second, tools / 'second')
     assert (tools / 'first').read_bytes() == b'first'
     assert (tools / 'second').read_bytes() == b'second'
+
+
+def test_stage_container_native_tool_revalidates_the_admitted_digest(tmp_path: Path) -> None:
+    source = tmp_path / 'skylos-go'
+    atomic_write_bytes(source, b'go-engine')
+    source.chmod(0o755)
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=source, sha256=digest)
+
+    destination = tmp_path / 'context' / 'native-tools' / tool.variable
+    stage_container_native_tool(tool, destination)
+    assert destination.read_bytes() == b'go-engine'
+    assert destination.stat().st_mode & 0o777 == 0o555
+    assert tool.container_path == PurePosixPath('/liveness/native-tools/SKYLOS_GO_BIN')
+    assert tool.identity == f'SKYLOS_GO_BIN sha256:{digest}'
+
+    atomic_write_bytes(source, b'changed-engine')
+    with pytest.raises(ContainerError, match='SKYLOS_GO_BIN changed after admission'):
+        stage_container_native_tool(tool, tmp_path / 'second-context' / tool.variable)
 
 
 def requirement_wheel(requirement: str) -> str:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -408,7 +408,7 @@ def write_linux_elf(
         Executable test-file path.
     """
     machine = {'x86_64': 62, 'aarch64': 183}[architecture]
-    header = bytearray(20)
+    header = bytearray(32)
     header[:7] = b'\x7fELF\x02\x01\x01'
     header[7] = os_abi
     header[16:18] = elf_type.to_bytes(2, byteorder='little')
@@ -453,35 +453,43 @@ def test_stage_static_binaries_share_one_tools_directory(tmp_path: Path) -> None
 
 
 def test_stage_container_native_tool_revalidates_the_admitted_digest(tmp_path: Path) -> None:
-    source = tmp_path / 'skylos-go'
-    atomic_write_bytes(source, b'go-engine')
-    source.chmod(0o755)
-    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    source = write_linux_elf(tmp_path / 'skylos-go', 'aarch64')
+    admitted = source.read_bytes()
+    digest = hashlib.sha256(admitted).hexdigest()
     tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=source, sha256=digest)
 
     destination = tmp_path / 'context' / 'native-tools' / tool.variable
-    stage_container_native_tool(tool, destination)
-    assert destination.read_bytes() == b'go-engine'
+    stage_container_native_tool(tool, destination, machine='aarch64')
+    assert destination.read_bytes() == admitted
     assert destination.stat().st_mode & 0o777 == 0o555
     assert tool.container_path == PurePosixPath('/liveness/native-tools/SKYLOS_GO_BIN')
     assert tool.identity == f'SKYLOS_GO_BIN sha256:{digest}'
 
     atomic_write_bytes(source, b'changed-engine')
     with pytest.raises(ContainerError, match='SKYLOS_GO_BIN changed after admission'):
-        stage_container_native_tool(tool, tmp_path / 'second-context' / tool.variable)
+        stage_container_native_tool(tool, tmp_path / 'second-context' / tool.variable, machine='aarch64')
+
+
+def test_stage_container_native_tool_validates_the_digest_matching_copy(tmp_path: Path) -> None:
+    source = tmp_path / 'skylos-go'
+    payload = b'\xcf\xfa\xed\xfe' + (b'host-native' * 3)
+    atomic_write_bytes(source, payload)
+    tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(payload).hexdigest())
+    with pytest.raises(ContainerError, match='not a supported 64-bit Linux ELF executable'):
+        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable, machine='aarch64')
 
 
 def test_stage_container_native_tool_names_an_invalid_operator_source(tmp_path: Path) -> None:
     missing = tmp_path / 'skylos-go'
     tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=missing, sha256='a' * 64)
     with pytest.raises(ContainerError, match='native helper SKYLOS_GO_BIN is missing: skylos-go'):
-        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable)
+        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable, machine='aarch64')
 
     target = tmp_path / 'engine'
     atomic_write_bytes(target, b'engine')
     missing.symlink_to(target)
     with pytest.raises(ContainerError, match='native helper SKYLOS_GO_BIN is not a regular file: skylos-go'):
-        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable)
+        stage_container_native_tool(tool, tmp_path / 'context' / tool.variable, machine='aarch64')
 
 
 @pytest.mark.parametrize('machine', ['aarch64', 'arm64'])
@@ -491,6 +499,16 @@ def test_validate_container_native_tool_accepts_matching_linux_elf(tmp_path: Pat
         variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(source.read_bytes()).hexdigest()
     )
     validate_container_native_tool_platform(tool, machine)
+
+
+def test_validate_container_native_tool_binds_header_to_admitted_digest(tmp_path: Path) -> None:
+    source = tmp_path / 'skylos-go'
+    admitted = b'\xcf\xfa\xed\xfe' + (b'host-native' * 3)
+    atomic_write_bytes(source, admitted)
+    tool = ContainerNativeTool(variable='SKYLOS_GO_BIN', source=source, sha256=hashlib.sha256(admitted).hexdigest())
+    write_linux_elf(source, 'aarch64')
+    with pytest.raises(ContainerError, match='native helper SKYLOS_GO_BIN changed after admission'):
+        validate_container_native_tool_platform(tool, 'aarch64')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1350,25 +1350,57 @@ def test_container_run_stages_the_skylos_neutral_config(
         assert 'SKYLOS_GREP_BUDGET=150' in argv
 
 
-def test_container_run_refuses_native_helper_passthrough(tmp_path: Path) -> None:
-    # A host executable cannot run inside the Linux container, so admitting
-    # one would silently degrade both sides' analysis (contract §3).
+def test_container_run_stages_native_helper_for_both_sides(
+    tmp_path: Path,
+    corpus_project: CorpusProject,
+    fake_detector_repo: str,
+) -> None:
+    # The admitted helper is pinned into both images and each invocation
+    # receives its container-side path (contract §3, §11).
     engine = write_fake_native_engine(tmp_path / 'skylos-go')
+    digest = hashlib.sha256(engine.read_bytes()).hexdigest()
     docker = FakeDocker()
     environments = ContainerEnvironments(CheckoutStore(tmp_path / 'cache'), tmp_path / 'cache', docker=docker)
+    exec_argvs: list[tuple[str, ...]] = []
+
+    async def docker_exec_launcher(
+        argv: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> LaunchResult:
+        del cwd, env
+        await asyncio.sleep(0)
+        exec_argvs.append(tuple(argv))
+        return LaunchResult(
+            argv=tuple(argv), returncode=0, stdout='{}', stderr='', duration_seconds=0.0, timed_out=False
+        )
+
     runner = PrimerRunner(
         adapter=get_adapter('skylos'),
         store=CheckoutStore(tmp_path / 'cache'),
         isolation=CONTAINER_ISOLATION,
         options=DEFAULT_OPTIONS,
+        async_launcher=docker_exec_launcher,
         environ={'SKYLOS_GO_BIN': str(engine)},
     )
-    with pytest.raises(RunnerError, match=r'SKYLOS_GO_BIN.*not supported in --container mode'):
-        runner.run_container(
-            [],
-            detector_repo='https://example.invalid/repo',
-            base_ref='a',
-            head_ref='b',
-            environments=environments,
-        )
-    assert docker.events == []
+    report = runner.run_container(
+        [corpus_project],
+        detector_repo=fake_detector_repo,
+        base_ref='base-branch',
+        head_ref='head-branch',
+        environments=environments,
+    )
+
+    assert not report_has_failures(report)
+    assert len(exec_argvs) == 2
+    for argv in exec_argvs:
+        assert 'SKYLOS_GO_BIN=/liveness/native-tools/SKYLOS_GO_BIN' in argv
+    for names, dockerfile in docker.built_contexts:
+        assert 'native-tools/SKYLOS_GO_BIN' in names
+        assert 'COPY native-tools/SKYLOS_GO_BIN /liveness/native-tools/SKYLOS_GO_BIN' in dockerfile
+    (record,) = report.manifest.native_tools
+    assert record.variable == 'SKYLOS_GO_BIN'
+    assert record.sha256 == digest
+    assert report.manifest.installer is not None
+    assert report.manifest.installer.endswith(f'SKYLOS_GO_BIN sha256:{digest}')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -43,7 +43,7 @@ from liveness_primer.runner import (
 )
 from liveness_primer.testing import FakeFinding, create_fake_project, write_fake_detector_script
 from liveness_primer.tools.registry import get_adapter
-from tests.test_container import FakeDocker
+from tests.test_container import FakeDocker, write_linux_elf
 
 BASE_FINDING = FakeFinding(path='pkg/mod.py', line=5, symbol='unused_helper', kind='function', confidence=60)
 MOVED_FINDING = FakeFinding(path='pkg/mod.py', line=9, symbol='unused_helper', kind='function', confidence=60)
@@ -1357,7 +1357,7 @@ def test_container_run_stages_native_helper_for_both_sides(
 ) -> None:
     # The admitted helper is pinned into both images and each invocation
     # receives its container-side path (contract §3, §11).
-    engine = write_fake_native_engine(tmp_path / 'skylos-go')
+    engine = write_linux_elf(tmp_path / 'skylos-go', 'aarch64')
     digest = hashlib.sha256(engine.read_bytes()).hexdigest()
     docker = FakeDocker()
     environments = ContainerEnvironments(CheckoutStore(tmp_path / 'cache'), tmp_path / 'cache', docker=docker)


### PR DESCRIPTION
## Summary

- stage admitted native helpers into both offline container images
- include helper digests in image fingerprints and installer provenance, and fail if bytes change after admission
- point each container invocation at the staged helper while preserving Skylos's pinned `rg`

The calling workflow still owns the trusted build: it must provide a Linux-compatible `SKYLOS_GO_BIN` before invoking liveness_primer.

## Validation

- `prek run --all-files`
- 678 passed, 3 skipped
- 100% line and branch coverage
- Mypy, Pyright, pydoclint, and Skylos
- Docker smoke test against Bubble Tea with Skylos PR #19's base/head refs and a trusted-base Linux Go engine
