### PR TITLE
ci: harden the artifact install jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,12 +73,16 @@ jobs:
           name: dist
           path: dist/
 
+      # No cache: with no checkout there is no stable file to key on, and the
+      # freshly built wheel hashes differently on every run (setuptools stamps
+      # zip entries from checkout mtimes), so a cache keyed on it would never
+      # hit while still writing a new entry every run. The handful of runtime
+      # dependencies downloads in seconds.
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: ${{ matrix.python-version }}
-          cache-dependency-glob: "dist/*.whl"
 
       - name: Install built wheel (${{ matrix.resolution }} resolution)
         run: |
@@ -87,3 +91,54 @@ jobs:
 
       - name: Import check
         run: .venv/bin/python -I -c "import liveness_primer"
+
+  install-sdist:
+    # The wheel matrix above covers what PyPI users install; this covers the
+    # other published artifact. Nothing else in CI installs the sdist, and a
+    # source tree that builds a correct wheel can still ship an sdist missing
+    # its package data -- which installs and imports fine and only breaks at
+    # runtime -- so the check below reads the declared package data rather
+    # than merely importing. Pinned to the newest declared-support Python:
+    # build-backend breakage under the 3.15 preview is already tracked by the
+    # advisory matrix entry in test.yml, and need not be duplicated here.
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      # No cache, for the same reason as the wheel matrix above.
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          enable-cache: false
+          python-version: "3.14"
+
+      - name: Install built sdist
+        run: |
+          uv venv --python 3.14
+          uv pip install dist/*.tar.gz
+
+      - name: Import check
+        run: .venv/bin/python -I -c "import liveness_primer"
+
+      - name: Packaged data check
+        run: |
+          .venv/bin/python -I - <<'PY'
+          from importlib.resources import files
+
+          root = files('liveness_primer')
+          missing = []
+          if not root.joinpath('py.typed').is_file():
+              missing.append('py.typed')
+          for subdir, suffix in (('schemas', '.schema.json'), ('tools', '.toml'), ('data', '.yaml')):
+              entry = root.joinpath(subdir)
+              if not entry.is_dir() or not any(child.name.endswith(suffix) for child in entry.iterdir()):
+                  missing.append(f'{subdir}/*{suffix}')
+          if missing:
+              raise SystemExit(f"::error::sdist install is missing declared package data: {', '.join(missing)}")
+          print('declared package data is present')
+          PY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,20 +125,34 @@ jobs:
       - name: Import check
         run: .venv/bin/python -I -c "import liveness_primer"
 
+      # Enumerate the expectations from the installed package itself rather
+      # than from a list duplicated here: EXPORTED_MODELS names every schema
+      # the code loads, so adding a model extends this check automatically.
+      # Staleness is already gated by tests/test_schema_export.py against the
+      # source tree; what only an installed artifact can prove is that each
+      # declared file actually shipped.
       - name: Packaged data check
         run: |
           .venv/bin/python -I - <<'PY'
           from importlib.resources import files
 
+          from liveness_primer.config import default_corpus_path
+          from liveness_primer.schema_export import EXPORTED_MODELS, schemas_dir
+
           root = files('liveness_primer')
-          missing = []
+          schemas = schemas_dir()
+          missing = [
+              f'schemas/{name}.schema.json'
+              for name in EXPORTED_MODELS
+              if not (schemas / f'{name}.schema.json').is_file()
+          ]
           if not root.joinpath('py.typed').is_file():
               missing.append('py.typed')
-          for subdir, suffix in (('schemas', '.schema.json'), ('tools', '.toml'), ('data', '.yaml')):
-              entry = root.joinpath(subdir)
-              if not entry.is_dir() or not any(child.name.endswith(suffix) for child in entry.iterdir()):
-                  missing.append(f'{subdir}/*{suffix}')
+          if not default_corpus_path().is_file():
+              missing.append('data/corpus.yaml')
+          if not root.joinpath('tools').joinpath('skylos_neutral_config.toml').is_file():
+              missing.append('tools/skylos_neutral_config.toml')
           if missing:
-              raise SystemExit(f"::error::sdist install is missing declared package data: {', '.join(missing)}")
-          print('declared package data is present')
+              raise SystemExit(f"::error::sdist install is missing declared package data: {', '.join(sorted(missing))}")
+          print(f'declared package data is present ({len(EXPORTED_MODELS)} schemas, corpus, skylos config, py.typed)')
           PY


### PR DESCRIPTION
## Summary

Follow-up to #75, from reviewing it after the merge. Two issues in the new `install` job:

- **The uv cache could never hit.** `cache-dependency-glob: \"dist/*.whl\"` keys the setup-uv cache on the built wheel, but setuptools stamps wheel zip entries from checkout mtimes, so the wheel — and the key — differ on every run. All four matrix jobs missed the cache and then wrote four fresh entries per run, pressuring the repo's cache budget and evicting entries other workflows do hit. Disabled instead; the six runtime dependencies download in seconds.
- **Nothing in CI installed the sdist.** `uv build` produces it, `twine check` validates its metadata and `publish.yml` uploads it to PyPI, but no job ever installed it. A source tree that builds a correct wheel can still ship an sdist missing its package data — which installs and imports fine, and only fails at runtime. New `install-sdist` job installs `dist/*.tar.gz` on 3.14 and checks the declared package data rather than merely importing.

The data check enumerates its expectations from the installed package instead of a list duplicated in YAML: `EXPORTED_MODELS` for the nine schemas, `default_corpus_path()` for the corpus, plus `tools/skylos_neutral_config.toml` by name. Adding a model extends the check on its own. It tests existence, not staleness — `tests/test_schema_export.py` already gates `stale_schemas()` against the source tree, and what only an installed artifact can prove is that each declared file shipped.

Pinned to 3.14 rather than the 3.15 preview: build-backend breakage under 3.15 is already tracked by the advisory matrix entry in `test.yml`, and a second advisory job would only add noise.

## Validation

- `prek run --files .github/workflows/build.yml` (actionlint included)
- Built the sdist locally, extracted it, built a wheel from the extracted sdist, and installed that layout into a venv — all four package-data sets survive the round trip
- Ran the `Packaged data check` step text, extracted from the committed YAML, against that install under `-I`: passes clean; removing a single `report.schema.json` fails with `::error::sdist install is missing declared package data: schemas/report.schema.json`; removing the corpus and skylos config too names all three in one message

🤖 Generated with [Claude Code](https://claude.com/claude-code)