### PR TITLE
fix(report): surface structured detector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ independently of the package version; `liveness-primer --version` prints both.
   and Skylos, scoped to `liveness_primer` and `tests` to match the committed
   Dead Code workflow. Skylos is `expected_clean` at the pin; Vulture is not.
 
+### Fixed
+
+- **Detector failure detail** — a failed invocation now records both its
+  stderr tail and the detector's own structured errors (Skylos
+  `analysis_errors`, up to five, each naming the file and line it is about),
+  so stderr noise no longer hides why a run failed. Truncated detail states
+  how much was omitted, and a failure with no diagnostic text no longer ends
+  in a dangling separator. The report schema and CLI are unchanged.
+
 ## [0.1.1] - 2026-08-21
 
 ### Added

--- a/liveness_primer/report/github.py
+++ b/liveness_primer/report/github.py
@@ -42,6 +42,7 @@ from liveness_primer.report.common import (
 )
 from liveness_primer.report.permalink import source_url, tree_url
 from liveness_primer.report.sanitize import (
+    FAILURE_DETAIL_RENDER_CAP,
     code_cell,
     code_span,
     escape_argv_text,
@@ -262,8 +263,12 @@ def _project_lines(project: ProjectReport, *, manifest: RunManifest, has_severit
             lines.append(f'- **corpus**: {repo_label} @ {sha_label}')
     lines.extend(f'- **rollup**: {sanitize_cell(rollup)}' for rollup in rollup_lines(project.rollups))
     # Error details quote detector stderr — attacker-influenced text that
-    # must not reach markdown unescaped (contract §9).
-    lines.extend(f'- **error[{error.side}]**: {sanitize_cell(error.detail)}' for error in project.errors)
+    # must not reach markdown unescaped (contract §9). They are rendered
+    # whole so the structured account after the stderr tail survives.
+    lines.extend(
+        f'- **error[{error.side}]**: {sanitize_cell(error.detail, max_length=FAILURE_DETAIL_RENDER_CAP)}'
+        for error in project.errors
+    )
     lines.extend(
         f'- **warning[corpus-integrity]**: {sanitize_cell(warning.detail)}' for warning in project.integrity_warnings
     )

--- a/liveness_primer/report/sanitize.py
+++ b/liveness_primer/report/sanitize.py
@@ -31,6 +31,36 @@ def _clean(text: str) -> str:
     return ''.join(ch if ch.isprintable() else ' ' for ch in text)
 
 
+def _marker_budget(length: int, max_length: int) -> tuple[int, int] | None:
+    """Split a cap between kept text and a ``...(+N)`` omission marker.
+
+    Parameters
+    ----------
+    length : int
+        Length of the text to bound; longer than the cap.
+    max_length : int
+        Maximum rendered length.
+
+    Returns
+    -------
+    tuple[int, int] | None
+        ``(kept, omitted)`` character counts whose marker fits the cap, or
+        ``None`` when the cap is too tiny for any marker.
+    """
+    # The marker length depends on the omitted count's digits, which in
+    # turn depends on how much is kept: walk digit budgets upward until
+    # the count fits its budget (it grows by at most one digit per step).
+    digits = 1
+    while True:
+        kept = max_length - (6 + digits)
+        if kept < 1:
+            return None
+        omitted = length - kept
+        if len(str(omitted)) <= digits:
+            return kept, omitted
+        digits += 1
+
+
 def _end_truncated(cleaned: str, max_length: int) -> str:
     """Truncate at the end with a marker stating the omitted count.
 
@@ -46,18 +76,63 @@ def _end_truncated(cleaned: str, max_length: int) -> str:
     str
         Truncated text within the cap; tiny caps fall back to a hard cut.
     """
-    # The marker length depends on the omitted count's digits, which in
-    # turn depends on how much is kept: walk digit budgets upward until
-    # the count fits its budget (it grows by at most one digit per step).
-    digits = 1
-    while True:
-        kept = max_length - (6 + digits)
-        if kept < 1:
-            return cleaned[:max_length]
-        omitted = len(cleaned) - kept
-        if len(str(omitted)) <= digits:
-            return f'{cleaned[:kept]}...(+{omitted})'
-        digits += 1
+    budget = _marker_budget(len(cleaned), max_length)
+    if budget is None:
+        return cleaned[:max_length]
+    kept, omitted = budget
+    return f'{cleaned[:kept]}...(+{omitted})'
+
+
+def truncate_end(text: str, max_length: int) -> str:
+    """Bound text by keeping its beginning, marking how much was cut.
+
+    Unlike :func:`sanitize_inline`, the text is not cleaned: this bounds
+    what a record stores, not what a renderer prints.
+
+    Parameters
+    ----------
+    text : str
+        Text to bound.
+    max_length : int
+        Maximum length.
+
+    Returns
+    -------
+    str
+        The text unchanged when it fits; otherwise its head followed by a
+        marker stating the omitted character count.
+    """
+    if len(text) <= max_length:
+        return text
+    return _end_truncated(text, max_length)
+
+
+def truncate_start(text: str, max_length: int) -> str:
+    """Bound text by keeping its end, marking how much was cut.
+
+    The tail is the identifying portion of a traceback or log, which ends
+    with the failure itself.
+
+    Parameters
+    ----------
+    text : str
+        Text to bound.
+    max_length : int
+        Maximum length.
+
+    Returns
+    -------
+    str
+        The text unchanged when it fits; otherwise a marker stating the
+        omitted character count followed by the text's tail.
+    """
+    if len(text) <= max_length:
+        return text
+    budget = _marker_budget(len(text), max_length)
+    if budget is None:
+        return text[-max_length:] if max_length else ''
+    kept, omitted = budget
+    return f'...(+{omitted}){text[-kept:]}'
 
 
 def sanitize_inline(text: str, *, max_length: int = DEFAULT_INLINE_CAP) -> str:

--- a/liveness_primer/report/sanitize.py
+++ b/liveness_primer/report/sanitize.py
@@ -14,6 +14,15 @@ injection reliably (contract §11).
 
 DEFAULT_INLINE_CAP = 300
 
+# Each account of a failed detector invocation (its stderr tail, its
+# structured detail) is bounded to this many characters when recorded.
+FAILURE_DETAIL_PART_CAP = 500
+
+# Renderers show a recorded failure detail whole: both accounts plus the
+# exit-code prefix, separators, and a parse-failure suffix. Failures are
+# rare (at most one per project side), so this one line may run long.
+FAILURE_DETAIL_RENDER_CAP = 2 * FAILURE_DETAIL_PART_CAP + 200
+
 
 def _clean(text: str) -> str:
     """Replace non-printable characters (controls, separators) with spaces.

--- a/liveness_primer/report/text.py
+++ b/liveness_primer/report/text.py
@@ -46,7 +46,12 @@ from liveness_primer.report.common import (
     totals_text,
 )
 from liveness_primer.report.permalink import source_url, tree_reference
-from liveness_primer.report.sanitize import escape_argv_text, sanitize_inline, sanitize_location
+from liveness_primer.report.sanitize import (
+    FAILURE_DETAIL_RENDER_CAP,
+    escape_argv_text,
+    sanitize_inline,
+    sanitize_location,
+)
 from liveness_primer.report.table import (
     Cell,
     Line,
@@ -689,7 +694,10 @@ def _project_lines(
         lines.append(_corpus_line(pin, options=options))
     lines.extend(_plain_line('  ' + rollup) for rollup in rollup_lines(project.rollups))
     lines.extend(
-        _plain_line(f'  error[{error.side}]: {sanitize_inline(error.detail)}', 'error') for error in project.errors
+        _plain_line(
+            f'  error[{error.side}]: {sanitize_inline(error.detail, max_length=FAILURE_DETAIL_RENDER_CAP)}', 'error'
+        )
+        for error in project.errors
     )
     lines.extend(
         _plain_line(f'  warning[corpus-integrity]: {sanitize_inline(warning.detail)}', 'warning')

--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -53,15 +53,11 @@ from liveness_primer.findings import (
 from liveness_primer.isolation import Isolation
 from liveness_primer.launcher import AsyncLauncher, LaunchResult, run_async
 from liveness_primer.locators import attach_locators
-from liveness_primer.report.sanitize import truncate_end, truncate_start
+from liveness_primer.report.sanitize import FAILURE_DETAIL_PART_CAP, truncate_end, truncate_start
 from liveness_primer.report.source import collect_source_evidence
 from liveness_primer.tools.base import AdapterError, DetectorAdapter, RawToolOutput, build_invocation
 
 GATE_CHOICES = ('new', 'dropped', 'changed', 'any', 'corpus-integrity')
-
-# Bound on each part of a recorded failure detail (contract §8 keeps the
-# full detail in the JSON report, which must still stay readable).
-_DETAIL_CAP = 500
 
 _DIGEST_CHUNK = 1_048_576
 
@@ -533,9 +529,9 @@ class PrimerRunner:
             # traceback ends with the exception) and the detector's own
             # structured detail keeps its head (the first reported errors).
             # Incidental stderr noise must not hide the structured detail.
-            stderr_detail = truncate_start(result.stderr.strip(), _DETAIL_CAP)
-            adapter_detail = self._adapter.failure_detail(raw, root=root) or ''
-            parts = [part for part in (stderr_detail, truncate_end(adapter_detail, _DETAIL_CAP)) if part]
+            stderr_detail = truncate_start(result.stderr.strip(), FAILURE_DETAIL_PART_CAP)
+            adapter_detail = truncate_end(self._adapter.failure_detail(raw, root=root) or '', FAILURE_DETAIL_PART_CAP)
+            parts = [part for part in (stderr_detail, adapter_detail) if part]
             detail = f'exit code {result.returncode}'
             if parts:
                 detail += f': {"; ".join(parts)}'

--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -519,9 +519,19 @@ class PrimerRunner:
         _SideOutcome
             The parsed outcome.
         """
+        raw = RawToolOutput(
+            returncode=result.returncode if result.returncode is not None else 0,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
         error: ToolError | None = None
         if result.returncode not in self._adapter.success_exit_codes:
-            detail = f'exit code {result.returncode}: {result.stderr.strip()[-_STDERR_SNIPPET:]}'
+            stderr_detail = result.stderr.strip()[-_STDERR_SNIPPET:]
+            adapter_detail = self._adapter.failure_detail(raw) if not stderr_detail else None
+            error_detail = stderr_detail or (adapter_detail[:_STDERR_SNIPPET] if adapter_detail is not None else '')
+            detail = f'exit code {result.returncode}'
+            if error_detail:
+                detail += f': {error_detail}'
             error = ToolError(side=side, exit_code=result.returncode, detail=detail)
             if not result.stdout.strip():
                 return _SideOutcome(
@@ -531,11 +541,6 @@ class PrimerRunner:
                     duration_seconds=result.duration_seconds,
                     returncode=result.returncode,
                 )
-        raw = RawToolOutput(
-            returncode=result.returncode if result.returncode is not None else 0,
-            stdout=result.stdout,
-            stderr=result.stderr,
-        )
         try:
             findings = self._adapter.parse(raw, project=item.project.name, root=root, analyses=item.settings.analyses)
         except AdapterError as exc:

--- a/liveness_primer/runner.py
+++ b/liveness_primer/runner.py
@@ -53,12 +53,15 @@ from liveness_primer.findings import (
 from liveness_primer.isolation import Isolation
 from liveness_primer.launcher import AsyncLauncher, LaunchResult, run_async
 from liveness_primer.locators import attach_locators
+from liveness_primer.report.sanitize import truncate_end, truncate_start
 from liveness_primer.report.source import collect_source_evidence
 from liveness_primer.tools.base import AdapterError, DetectorAdapter, RawToolOutput, build_invocation
 
 GATE_CHOICES = ('new', 'dropped', 'changed', 'any', 'corpus-integrity')
 
-_STDERR_SNIPPET = 500
+# Bound on each part of a recorded failure detail (contract §8 keeps the
+# full detail in the JSON report, which must still stay readable).
+_DETAIL_CAP = 500
 
 _DIGEST_CHUNK = 1_048_576
 
@@ -526,12 +529,16 @@ class PrimerRunner:
         )
         error: ToolError | None = None
         if result.returncode not in self._adapter.success_exit_codes:
-            stderr_detail = result.stderr.strip()[-_STDERR_SNIPPET:]
-            adapter_detail = self._adapter.failure_detail(raw) if not stderr_detail else None
-            error_detail = stderr_detail or (adapter_detail[:_STDERR_SNIPPET] if adapter_detail is not None else '')
+            # Record both accounts of the failure: stderr keeps its tail (a
+            # traceback ends with the exception) and the detector's own
+            # structured detail keeps its head (the first reported errors).
+            # Incidental stderr noise must not hide the structured detail.
+            stderr_detail = truncate_start(result.stderr.strip(), _DETAIL_CAP)
+            adapter_detail = self._adapter.failure_detail(raw, root=root) or ''
+            parts = [part for part in (stderr_detail, truncate_end(adapter_detail, _DETAIL_CAP)) if part]
             detail = f'exit code {result.returncode}'
-            if error_detail:
-                detail += f': {error_detail}'
+            if parts:
+                detail += f': {"; ".join(parts)}'
             error = ToolError(side=side, exit_code=result.returncode, detail=detail)
             if not result.stdout.strip():
                 return _SideOutcome(

--- a/liveness_primer/tools/base.py
+++ b/liveness_primer/tools/base.py
@@ -206,18 +206,22 @@ class DetectorAdapter(Protocol):
         """
         ...
 
-    def failure_detail(self, output: RawToolOutput) -> str | None:
+    def failure_detail(self, output: RawToolOutput, *, root: PurePath) -> str | None:
         """Extract detector-specific detail from a failed invocation.
 
         Parameters
         ----------
         output : RawToolOutput
             Captured detector output with a non-success exit code.
+        root : PurePath
+            Checkout root as the detector saw it, for path normalization.
 
         Returns
         -------
         str | None
-            Structured failure detail, when the detector reports it.
+            Structured failure detail, when the detector reports it. The
+            runner records it alongside the stderr snippet, so it should
+            name what stderr does not (which files failed, and why).
         """
         ...
 

--- a/liveness_primer/tools/base.py
+++ b/liveness_primer/tools/base.py
@@ -206,6 +206,21 @@ class DetectorAdapter(Protocol):
         """
         ...
 
+    def failure_detail(self, output: RawToolOutput) -> str | None:
+        """Extract detector-specific detail from a failed invocation.
+
+        Parameters
+        ----------
+        output : RawToolOutput
+            Captured detector output with a non-success exit code.
+
+        Returns
+        -------
+        str | None
+            Structured failure detail, when the detector reports it.
+        """
+        ...
+
 
 def build_invocation(adapter: DetectorAdapter, executable: Sequence[str], settings: ToolSettings) -> list[str]:
     """Compose the analysis argv for one (project, tool) pair (contract §11).

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -70,6 +70,10 @@ _NEUTRAL_CONFIG = Path(__file__).with_name('skylos_neutral_config.toml')
 # the pass cannot on its own starve the rest of the run.
 _GREP_BUDGET_SECONDS = '150'
 
+# One failed invocation can report an error per skipped file. Keep the
+# diagnostic useful without allowing that list to dominate the report.
+_ANALYSIS_ERROR_LIMIT = 5
+
 # Documented, versioned mapping from each ingested single-rule skylos
 # symbol bucket to its canonical rule ID (reporting contract §3.1). A rule
 # ID explicitly present on the detector finding takes precedence; a rule ID
@@ -205,6 +209,44 @@ class SkylosAdapter:
         output_format='json',
     )
     build_recipe: BuildRecipe = BuildRecipe(backend='python-source')
+
+    @staticmethod
+    def failure_detail(output: RawToolOutput) -> str | None:
+        """Extract bounded analysis errors from skylos JSON output.
+
+        Parameters
+        ----------
+        output : RawToolOutput
+            Captured skylos output.
+
+        Returns
+        -------
+        str | None
+            Up to five analysis-error messages, when present and valid.
+        """
+        try:
+            document = json.loads(output.stdout)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(document, dict):
+            return None
+        raw_errors = document.get('analysis_errors')
+        if not isinstance(raw_errors, list):
+            return None
+
+        details: list[str] = []
+        for raw_error in raw_errors:
+            if not isinstance(raw_error, dict):
+                continue
+            message = raw_error.get('message')
+            if not isinstance(message, str) or not message.strip():
+                continue
+            kind = raw_error.get('kind')
+            prefix = f'{kind.strip()}: ' if isinstance(kind, str) and kind.strip() else ''
+            details.append(prefix + message.strip())
+            if len(details) == _ANALYSIS_ERROR_LIMIT:
+                break
+        return '\n'.join(details) or None
 
     @staticmethod
     def parse(output: RawToolOutput, *, project: str, root: PurePath, analyses: tuple[str, ...] = ()) -> list[Finding]:

--- a/liveness_primer/tools/skylos.py
+++ b/liveness_primer/tools/skylos.py
@@ -8,6 +8,7 @@ arrays are always ingested; the diagnostic arrays (``danger``, ``secrets``,
 when a corpus config opts into the matching analysis (contract §4, §5).
 """
 
+import functools
 import json
 from collections.abc import Mapping
 from pathlib import Path, PurePath
@@ -73,6 +74,70 @@ _GREP_BUDGET_SECONDS = '150'
 # One failed invocation can report an error per skipped file. Keep the
 # diagnostic useful without allowing that list to dominate the report.
 _ANALYSIS_ERROR_LIMIT = 5
+
+
+@functools.lru_cache(maxsize=1)
+def _load_document(stdout: str) -> object:
+    """Decode skylos stdout, remembering the most recent document.
+
+    A failed invocation that still produced output is decoded twice in a
+    row: once for its failure detail and once for its findings. A
+    single-entry cache spares the second decode of a document that can
+    run to megabytes on a large corpus project, while retaining at most
+    one document beyond the invocation that produced it.
+
+    Parameters
+    ----------
+    stdout : str
+        Captured skylos standard output.
+
+    Returns
+    -------
+    object
+        The decoded JSON value.
+
+    Raises
+    ------
+    AdapterError
+        If stdout is not valid JSON.
+    """
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        msg = f'skylos output is not valid JSON: {exc}'
+        raise AdapterError(msg) from exc
+
+
+def _analysis_error_location(raw_error: Mapping[str, object], root: PurePath) -> str:
+    """Name the file (and line) one skylos analysis error is about.
+
+    Parameters
+    ----------
+    raw_error : Mapping[str, object]
+        One ``analysis_errors`` entry (untrusted).
+    root : PurePath
+        Checkout directory skylos analyzed, for path normalization.
+
+    Returns
+    -------
+    str
+        ``path`` or ``path:line`` relative to the checkout, or the empty
+        string when the entry names no usable file.
+    """
+    file = raw_error.get('file')
+    if not isinstance(file, str) or not file.strip():
+        return ''
+    try:
+        path = normalize_finding_path(file, root, allow_root=True)
+    except AdapterError:
+        # A path outside the checkout is malformed detector output; keep
+        # the message but not the path (contract §11).
+        return ''
+    line = raw_error.get('line')
+    if isinstance(line, int) and not isinstance(line, bool) and line >= 1:
+        return f'{path}:{line}'
+    return path
+
 
 # Documented, versioned mapping from each ingested single-rule skylos
 # symbol bucket to its canonical rule ID (reporting contract §3.1). A rule
@@ -211,22 +276,26 @@ class SkylosAdapter:
     build_recipe: BuildRecipe = BuildRecipe(backend='python-source')
 
     @staticmethod
-    def failure_detail(output: RawToolOutput) -> str | None:
+    def failure_detail(output: RawToolOutput, *, root: PurePath) -> str | None:
         """Extract bounded analysis errors from skylos JSON output.
 
         Parameters
         ----------
         output : RawToolOutput
             Captured skylos output.
+        root : PurePath
+            Checkout directory skylos analyzed, for path normalization.
 
         Returns
         -------
         str | None
-            Up to five analysis-error messages, when present and valid.
+            At most ``_ANALYSIS_ERROR_LIMIT`` analysis-error entries joined
+            by ``; ``, each ``path:line: kind: message`` with whichever of
+            those parts the entry provides; ``None`` without any.
         """
         try:
-            document = json.loads(output.stdout)
-        except json.JSONDecodeError:
+            document = _load_document(output.stdout)
+        except AdapterError:
             return None
         if not isinstance(document, dict):
             return None
@@ -242,11 +311,15 @@ class SkylosAdapter:
             if not isinstance(message, str) or not message.strip():
                 continue
             kind = raw_error.get('kind')
-            prefix = f'{kind.strip()}: ' if isinstance(kind, str) and kind.strip() else ''
-            details.append(prefix + message.strip())
+            parts = (
+                _analysis_error_location(raw_error, root),
+                kind.strip() if isinstance(kind, str) else '',
+                message.strip(),
+            )
+            details.append(': '.join(part for part in parts if part))
             if len(details) == _ANALYSIS_ERROR_LIMIT:
                 break
-        return '\n'.join(details) or None
+        return '; '.join(details) or None
 
     @staticmethod
     def parse(output: RawToolOutput, *, project: str, root: PurePath, analyses: tuple[str, ...] = ()) -> list[Finding]:
@@ -285,11 +358,7 @@ class SkylosAdapter:
                 msg = f'skylos does not provide analysis {name!r}'
                 raise AdapterError(msg)
             selected.add(_ANALYSIS_BUCKETS[name])
-        try:
-            document = json.loads(output.stdout)
-        except json.JSONDecodeError as exc:
-            msg = f'skylos output is not valid JSON: {exc}'
-            raise AdapterError(msg) from exc
+        document = _load_document(output.stdout)
         if not isinstance(document, dict):
             msg = 'skylos output is not a JSON object'
             raise AdapterError(msg)

--- a/liveness_primer/tools/vulture.py
+++ b/liveness_primer/tools/vulture.py
@@ -77,20 +77,22 @@ class VultureAdapter:
     build_recipe: BuildRecipe = BuildRecipe(backend='python-source')
 
     @staticmethod
-    def failure_detail(output: RawToolOutput) -> str | None:
+    def failure_detail(output: RawToolOutput, *, root: PurePath) -> str | None:
         """Return no structured failure detail for vulture output.
 
         Parameters
         ----------
         output : RawToolOutput
             Captured vulture output.
+        root : PurePath
+            Checkout directory vulture analyzed.
 
         Returns
         -------
         str | None
             Vulture reports operational errors on standard error.
         """
-        del output
+        del output, root
         return None
 
     @staticmethod

--- a/liveness_primer/tools/vulture.py
+++ b/liveness_primer/tools/vulture.py
@@ -77,6 +77,23 @@ class VultureAdapter:
     build_recipe: BuildRecipe = BuildRecipe(backend='python-source')
 
     @staticmethod
+    def failure_detail(output: RawToolOutput) -> str | None:
+        """Return no structured failure detail for vulture output.
+
+        Parameters
+        ----------
+        output : RawToolOutput
+            Captured vulture output.
+
+        Returns
+        -------
+        str | None
+            Vulture reports operational errors on standard error.
+        """
+        del output
+        return None
+
+    @staticmethod
     def parse(output: RawToolOutput, *, project: str, root: PurePath, analyses: tuple[str, ...] = ()) -> list[Finding]:
         """Parse vulture stdout lines into findings.
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -59,6 +59,8 @@ from liveness_primer.report.sanitize import (
     sanitize_cell,
     sanitize_inline,
     sanitize_location,
+    truncate_end,
+    truncate_start,
 )
 from liveness_primer.report.terminal import TextRenderOptions
 
@@ -952,6 +954,21 @@ def test_sanitize_inline_never_exceeds_tiny_caps(cap: int, expected: str) -> Non
     # Regression: caps below the marker length must fall back to a hard cut
     # rather than exceeding the cap.
     assert sanitize_inline('x' * 50, max_length=cap) == expected
+
+
+def test_truncate_end_keeps_head_with_marker() -> None:
+    assert truncate_end('short', 10) == 'short'
+    assert truncate_end('x' * 400, 300) == 'x' * 291 + '...(+109)'
+    assert truncate_end('x' * 50, 8) == 'xxxxxxxx'
+
+
+def test_truncate_start_keeps_tail_with_marker() -> None:
+    assert truncate_start('short', 10) == 'short'
+    assert truncate_start('a' * 109 + 'b' * 291, 300) == '...(+109)' + 'b' * 291
+    assert truncate_start('y' * 50, 9) == '...(+49)y'
+    # Caps below the marker length fall back to a hard cut of the tail.
+    assert truncate_start('y' * 50, 8) == 'yyyyyyyy'
+    assert not truncate_start('y' * 50, 0)
 
 
 def test_sanitize_location_preserves_beginning_and_ending() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import hashlib
+import json
 import os
 import re
 import stat
@@ -181,6 +182,44 @@ def test_tool_failure_is_recorded_not_raised(tmp_path: Path, corpus_project: Cor
     assert project_report.diffs == ()
     assert project_report.measured_cost_seconds is None
     assert report_has_failures(report)
+
+
+def test_tool_failure_without_detail_omits_empty_separator(tmp_path: Path, corpus_project: CorpusProject) -> None:
+    base_cmd = write_fake_detector_script(tmp_path / 'base.json', [], exit_code=2)
+    head_cmd = write_fake_detector_script(tmp_path / 'head.json', [BASE_FINDING])
+    report = runner_for(tmp_path).run_escape_hatch([corpus_project], base_cmd=base_cmd, head_cmd=head_cmd)
+    (error,) = report.projects[0].errors
+    assert error.detail == 'exit code 2'
+
+
+def test_skylos_analysis_error_is_recorded_from_stdout(tmp_path: Path, corpus_project: CorpusProject) -> None:
+    document = {
+        'unused_functions': [{'name': 'a', 'type': 'function', 'file': 'a.py', 'line': 1}],
+        'analysis_errors': [
+            {
+                'kind': 'language_engine_unavailable',
+                'message': 'Go analysis incomplete: engine binary not found.',
+            }
+        ],
+    }
+    base_cmd = [
+        sys.executable,
+        '-c',
+        f'import sys; print({json.dumps(document)!r}); sys.exit(2)',
+    ]
+    head_cmd = write_fake_detector_script(tmp_path / 'head.json', [BASE_FINDING], output_format='skylos')
+    report = runner_for(tmp_path, tool='skylos').run_escape_hatch(
+        [corpus_project],
+        base_cmd=base_cmd,
+        head_cmd=head_cmd,
+    )
+    (error,) = report.projects[0].errors
+    assert error.detail == (
+        'exit code 2: language_engine_unavailable: Go analysis incomplete: engine binary not found.'
+    )
+    expected_message = 'Go analysis incomplete: engine binary not found.'
+    assert expected_message in render_text(report)
+    assert expected_message in render_github(report)
 
 
 def test_failed_skylos_with_empty_result_buckets_does_not_diff(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -233,7 +233,7 @@ def test_tool_failure_records_stderr_and_structured_detail(tmp_path: Path, corpu
         'import json, os, sys; '
         f'document = json.loads({json.dumps(document)!r}); '
         "document['analysis_errors'][0]['file'] = os.path.join(os.getcwd(), 'pkg', 'broken.py'); "
-        "sys.stderr.write('DeprecationWarning: noise\\n'); "
+        "sys.stderr.write('x' * 600 + 'Traceback END\\n'); "
         'print(json.dumps(document)); '
         'sys.exit(2)'
     )
@@ -244,7 +244,15 @@ def test_tool_failure_records_stderr_and_structured_detail(tmp_path: Path, corpu
         head_cmd=head_cmd,
     )
     (error,) = report.projects[0].errors
-    assert error.detail == 'exit code 2: DeprecationWarning: noise; pkg/broken.py:7: syntax_error: invalid syntax'
+    structured = 'pkg/broken.py:7: syntax_error: invalid syntax'
+    assert error.detail.startswith('exit code 2: ...(+')
+    assert error.detail.endswith(f'xTraceback END; {structured}')
+    # Both accounts survive the human renderers' caps: the stderr tail kept
+    # on purpose and the structured account after it.
+    for rendered in (render_text(report), render_github(report)):
+        assert 'xTraceback END; pkg/broken.py:7: syntax' in rendered
+        assert 'invalid syntax' in rendered
+        assert '...(+' not in rendered.split('xTraceback END', 1)[1]
 
 
 def test_tool_failure_detail_marks_truncated_stderr(tmp_path: Path, corpus_project: CorpusProject) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -222,6 +222,43 @@ def test_skylos_analysis_error_is_recorded_from_stdout(tmp_path: Path, corpus_pr
     assert expected_message in render_github(report)
 
 
+def test_tool_failure_records_stderr_and_structured_detail(tmp_path: Path, corpus_project: CorpusProject) -> None:
+    # Incidental stderr output must not hide the detector's own account of
+    # the failure, and that account names the file it is about.
+    document = {
+        'unused_functions': [{'name': 'a', 'type': 'function', 'file': 'a.py', 'line': 1}],
+        'analysis_errors': [{'kind': 'syntax_error', 'message': 'invalid syntax', 'line': 7}],
+    }
+    script = (
+        'import json, os, sys; '
+        f'document = json.loads({json.dumps(document)!r}); '
+        "document['analysis_errors'][0]['file'] = os.path.join(os.getcwd(), 'pkg', 'broken.py'); "
+        "sys.stderr.write('DeprecationWarning: noise\\n'); "
+        'print(json.dumps(document)); '
+        'sys.exit(2)'
+    )
+    head_cmd = write_fake_detector_script(tmp_path / 'head.json', [BASE_FINDING], output_format='skylos')
+    report = runner_for(tmp_path, tool='skylos').run_escape_hatch(
+        [corpus_project],
+        base_cmd=[sys.executable, '-c', script],
+        head_cmd=head_cmd,
+    )
+    (error,) = report.projects[0].errors
+    assert error.detail == 'exit code 2: DeprecationWarning: noise; pkg/broken.py:7: syntax_error: invalid syntax'
+
+
+def test_tool_failure_detail_marks_truncated_stderr(tmp_path: Path, corpus_project: CorpusProject) -> None:
+    # The recorded snippet keeps the end of stderr (where a traceback names
+    # its exception) and says how much it dropped.
+    base_cmd = write_fake_detector_script(tmp_path / 'base.json', [], exit_code=2, stderr='x' * 600 + 'END')
+    head_cmd = write_fake_detector_script(tmp_path / 'head.json', [BASE_FINDING])
+    report = runner_for(tmp_path).run_escape_hatch([corpus_project], base_cmd=base_cmd, head_cmd=head_cmd)
+    (error,) = report.projects[0].errors
+    assert error.detail.startswith('exit code 2: ...(+112)x')
+    assert error.detail.endswith('xEND')
+    assert len(error.detail) == len('exit code 2: ') + 500
+
+
 def test_failed_skylos_with_empty_result_buckets_does_not_diff(
     tmp_path: Path,
     corpus_project: CorpusProject,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -345,13 +345,46 @@ def test_skylos_accepts_failed_output_with_a_result_bucket() -> None:
 def test_skylos_extracts_bounded_analysis_error_details() -> None:
     errors = [{'kind': f'kind-{index}', 'message': f'failure {index}'} for index in range(6)]
     errors.append({'kind': 'missing-message'})
-    detail = SkylosAdapter.failure_detail(raw(json.dumps({'analysis_errors': errors}), returncode=2))
-    assert detail == '\n'.join(f'kind-{index}: failure {index}' for index in range(5))
+    detail = SkylosAdapter.failure_detail(raw(json.dumps({'analysis_errors': errors}), returncode=2), root=ROOT)
+    # Entries are joined on one line: renderers flatten newlines to spaces.
+    assert detail == '; '.join(f'kind-{index}: failure {index}' for index in range(5))
 
 
 def test_skylos_failure_detail_accepts_message_without_kind() -> None:
-    detail = SkylosAdapter.failure_detail(raw('{"analysis_errors": [{"message": "failure"}]}', returncode=2))
-    assert detail == 'failure'
+    output = raw('{"analysis_errors": [{"message": "failure"}]}', returncode=2)
+    assert SkylosAdapter.failure_detail(output, root=ROOT) == 'failure'
+
+
+def test_skylos_failure_detail_names_the_failed_file() -> None:
+    # Skylos reports one error per skipped file; the location is what tells
+    # them apart.
+    errors = [
+        {'kind': 'syntax_error', 'message': 'invalid syntax', 'file': '/checkout/pkg/a.py', 'line': 3},
+        {'kind': 'processing_error', 'message': 'boom', 'file': 'pkg/b.py'},
+        {'message': 'symlink scan root', 'file': '/checkout'},
+    ]
+    detail = SkylosAdapter.failure_detail(raw(json.dumps({'analysis_errors': errors}), returncode=2), root=ROOT)
+    assert detail == 'pkg/a.py:3: syntax_error: invalid syntax; pkg/b.py: processing_error: boom; .: symlink scan root'
+
+
+@pytest.mark.parametrize(
+    'entry',
+    [
+        {'file': '/elsewhere/a.py', 'line': 3},
+        {'file': '../escape.py'},
+        {'file': 5},
+        {'file': ' '},
+    ],
+)
+def test_skylos_failure_detail_omits_unusable_locations(entry: dict[str, object]) -> None:
+    document = {'analysis_errors': [{'kind': 'k', 'message': 'm', **entry}]}
+    assert SkylosAdapter.failure_detail(raw(json.dumps(document), returncode=2), root=ROOT) == 'k: m'
+
+
+@pytest.mark.parametrize('line', [0, -1, True, '3', None])
+def test_skylos_failure_detail_ignores_invalid_lines(line: object) -> None:
+    document = {'analysis_errors': [{'message': 'm', 'file': 'pkg/a.py', 'line': line}]}
+    assert SkylosAdapter.failure_detail(raw(json.dumps(document), returncode=2), root=ROOT) == 'pkg/a.py: m'
 
 
 @pytest.mark.parametrize(
@@ -367,7 +400,7 @@ def test_skylos_failure_detail_accepts_message_without_kind() -> None:
     ],
 )
 def test_skylos_failure_detail_rejects_unstructured_output(stdout: str) -> None:
-    assert SkylosAdapter.failure_detail(raw(stdout, returncode=2)) is None
+    assert SkylosAdapter.failure_detail(raw(stdout, returncode=2), root=ROOT) is None
 
 
 def test_vulture_findings_carry_no_invented_rule_id() -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -342,6 +342,34 @@ def test_skylos_accepts_failed_output_with_a_result_bucket() -> None:
     assert finding.symbol == 'a'
 
 
+def test_skylos_extracts_bounded_analysis_error_details() -> None:
+    errors = [{'kind': f'kind-{index}', 'message': f'failure {index}'} for index in range(6)]
+    errors.append({'kind': 'missing-message'})
+    detail = SkylosAdapter.failure_detail(raw(json.dumps({'analysis_errors': errors}), returncode=2))
+    assert detail == '\n'.join(f'kind-{index}: failure {index}' for index in range(5))
+
+
+def test_skylos_failure_detail_accepts_message_without_kind() -> None:
+    detail = SkylosAdapter.failure_detail(raw('{"analysis_errors": [{"message": "failure"}]}', returncode=2))
+    assert detail == 'failure'
+
+
+@pytest.mark.parametrize(
+    'stdout',
+    [
+        'not JSON',
+        '[]',
+        '{}',
+        '{"analysis_errors": {}}',
+        '{"analysis_errors": ["invalid"]}',
+        '{"analysis_errors": [{"kind": "missing-message"}]}',
+        '{"analysis_errors": [{"message": " "}]}',
+    ],
+)
+def test_skylos_failure_detail_rejects_unstructured_output(stdout: str) -> None:
+    assert SkylosAdapter.failure_detail(raw(stdout, returncode=2)) is None
+
+
 def test_vulture_findings_carry_no_invented_rule_id() -> None:
     # Reporting contract §3.1 and acceptance 4: a detector without a native
     # rule ID yields None, never an invented tool-specific code.


### PR DESCRIPTION
## Summary

- preserve existing stderr diagnostics and fall back to detector-specific structured output when stderr is empty
- surface up to five Skylos `analysis_errors` kind/message entries through the existing `ToolError.detail` string
- omit the dangling detail separator when a failed invocation provides no diagnostic text

This leaves the report schema and CLI unchanged.

## Testing

- `prek run --all-files`
- `pytest`: 701 passed, 3 skipped
- coverage.py: 100% combined line and branch coverage
- Mypy, Pyright, Pydoclint, and Ruff
